### PR TITLE
Better value decoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ services:
   - postgresql
 
 env:
-  - PG_HOST_PORT=localhost:5432
-  - PG_USER=postgres
-  - PG_DBNAME=finagle_postgres_test
+  - PG_HOST_PORT=localhost:5432 PG_USER=postgres PG_DBNAME=finagle_postgres_test
 
 before_script:
   - createdb -U postgres finagle_postgres_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,18 @@ scala:
   - 2.11.7
 
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
+
+services:
+  - postgresql
+
+env:
+  - PG_HOST_PORT=localhost:5432
+  - PG_USER=postgres
+  - PG_DBNAME=finagle_postgres_test
+
+before_script:
+  - createdb -U postgres finagle_postgres_test
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,12 @@ script:
 after_success:
   - sbt coveralls
 
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,8 @@ val baseSettings = Seq(
     "com.twitter" %% "finagle-core" % "6.35.0",
     "junit" % "junit" % "4.7" % "test,it",
     "org.scalatest" %% "scalatest" % "2.2.5" % "test,it",
-    "org.mockito" % "mockito-all" % "1.9.5" % "test,it"
+    "org.mockito" % "mockito-all" % "1.9.5" % "test,it",
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test,it"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val publishSettings = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
-lazy val root = project.in(file("."))
+lazy val `finagle-postgres` = project.in(file("."))
   .settings(moduleName := "finagle-postgres")
   .settings(allSettings)
   .configs(IntegrationTest)

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -1,32 +1,99 @@
 package com.twitter.finagle.postgres
 
+import java.nio.charset.{Charset, StandardCharsets}
+
 import com.twitter.finagle.{Service, ServiceFactory}
 import com.twitter.finagle.builder.ClientBuilder
-import com.twitter.finagle.postgres.codec.{CustomOIDProxy, PgCodec, Errors}
+import com.twitter.finagle.postgres.codec.{Errors, PgCodec}
 import com.twitter.finagle.postgres.messages._
-import com.twitter.finagle.postgres.values.{StringValueEncoder, ValueParser, Value}
+import com.twitter.finagle.postgres.values._
 import com.twitter.logging.Logger
-import com.twitter.util.Future
-
+import com.twitter.util.{Future, Return, Throw, Try}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.jboss.netty.buffer.ChannelBuffer
 
+import scala.collection.immutable.Queue
 import scala.util.Random
 
 /*
  * A Finagle client for communicating with Postgres.
  */
-class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
+class Client(
+  factory: ServiceFactory[PgRequest, PgResponse],
+  id:String,
+  types: Option[Map[Int, Client.TypeSpecifier]] = None,
+  customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
+  binaryResults: Boolean = false
+) {
   private[this] val counter = new AtomicInteger(0)
-  private[this] lazy val customTypes = CustomOIDProxy.serviceOIDMap(id)
   private[this] val logger = Logger(getClass.getName)
+  private val resultFormats = if(binaryResults) Seq(1) else Seq(0)
+
+  val charset = StandardCharsets.UTF_8
+
+  private def retrieveTypeMap() = {
+    //get a mapping of OIDs to the name of the receive function for all types in the remote DB.
+    //typreceive is the most reliable way to determine how a type should be decoded
+    val customTypesQuery =
+      """
+       |SELECT DISTINCT
+       |  CAST(t.typname AS text) AS type,
+       |  CAST(t.oid AS integer) AS oid,
+       |  CAST(t.typreceive AS text) AS typreceive,
+       |  CAST(t.typelem AS integer) AS typelem
+       |FROM           pg_type t
+       |WHERE          CAST(t.typreceive AS text) <> '-'
+     """.stripMargin
+
+    val serviceF = factory.apply
+
+    val bootstrapTypes = Map(
+      Type.INT_4 -> ValueDecoder.Int4,
+      Type.TEXT -> ValueDecoder.String
+    )
+
+    val customTypesResult = for {
+      service <- serviceF
+      response <- service.apply(new PgRequest(new Query(customTypesQuery)))
+    } yield response match {
+      case SelectResult(fields, rows) =>
+        val rowValues = rows.map {
+          row =>
+            row.data.zip(fields).map {
+              case (buf, field) =>
+                val decoder = bootstrapTypes(field.dataType)
+                if(field.format == 0)
+                  decoder.decodeText(Buffers.readString(buf, charset)).getOrElse(null)
+                else
+                  decoder.decodeBinary(buf, charset).getOrElse(null)
+            }
+        }
+        val fieldNames = fields.map(_.name)
+        rowValues.map(row => new Row(fieldNames, row)).map {
+          row => row.get[Int]("oid") -> Client.TypeSpecifier(row.get[String]("typreceive"), row.get[Int]("typelem"))
+        }.toMap
+    }
+
+    customTypesResult.ensure {
+      serviceF.foreach(_.close())
+    }
+
+    customTypesResult
+  }
+
+  val typeMap = types.map(Future(_)).getOrElse(retrieveTypeMap())
+
+  val decoders = customReceiveFunctions orElse ValueDecoder.decoders
+
 
   /*
    * Issue an arbitrary SQL query and get the response.
    */
   def query(sql: String): Future[QueryResponse] = sendQuery(sql) {
-    case SelectResult(fields, rows) => Future(ResultSet(fields, rows, customTypes))
+    case SelectResult(fields, rows) => processFields(fields).map {
+      case (names, parsers) => ResultSet(names, charset, parsers, rows)
+    }
     case CommandCompleteResponse(affected) => Future(OK(affected))
   }
 
@@ -47,9 +114,9 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   /*
    * Run a single SELECT query and wrap the results with the provided function.
    */
-  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql) map {
+  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql).flatMap {
     rs =>
-      extractRows(rs).map(f)
+      extractRows(rs).map(_.map(f))
   }
 
   /*
@@ -78,15 +145,15 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
     val preparedStatement = factory.apply().flatMap {
       service =>
         parse(sql, Some(service)).map { name =>
-	  new PreparedStatementImpl(name, service)
-	}
+          new PreparedStatementImpl(name, service)
+        }
     }
 
     preparedStatement.flatMap {
       statement =>
         statement.exec(params: _*).ensure {
-	  statement.closeService
-	}
+          statement.closeService
+        }
     } map {
       case OK(count) => count
     }
@@ -110,7 +177,7 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
       name: String,
       params: Seq[ChannelBuffer] = Seq(),
       optionalService: Option[Service[PgRequest, PgResponse]] = None): Future[Unit] = {
-    send(PgRequest(Bind(portal = name, name = name, params = params), flush = true), optionalService) {
+    send(PgRequest(Bind(portal = name, name = name, params = params, resultFormats = resultFormats), flush = true), optionalService) {
       case BindCompletedResponse => Future.value(())
     }
   }
@@ -118,11 +185,11 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   private[this] def describe(
       name: String,
       optionalService: Option[Service[PgRequest, PgResponse]] = None
-    ): Future[(IndexedSeq[String], IndexedSeq[ChannelBuffer => Value[Any]])] = {
+    ): Future[(IndexedSeq[String], IndexedSeq[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])] =
     send(PgRequest(Describe(portal = true, name = name), flush = true), optionalService) {
-      case RowDescriptions(fields) => Future.value(processFields(fields))
+      case RowDescriptions(fields) => processFields(fields)
     }
-  }
+
 
   private[this] def execute(
       name: String,
@@ -159,18 +226,33 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   }
 
   private[this] def processFields(
-      fields: IndexedSeq[Field]): (IndexedSeq[String], IndexedSeq[ChannelBuffer => Value[Any]]) = {
+      fields: IndexedSeq[Field]): Future[(IndexedSeq[String], IndexedSeq[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])] = {
     val names = fields.map(f => f.name)
-    val parsers = fields.map(f => ValueParser.parserOf(f.format, f.dataType, customTypes))
+    val parsers = fields.toList.map {
+      f => for {
+        types <- typeMap
+      } yield for {
+        Client.TypeSpecifier(recv, elem) <- types.get(f.dataType)
+        decoder <- decoders.lift.apply(recv)
+      } yield if(f.format != 0) (decoder.decodeBinary _).tupled else (Buffers.readString _).tupled.andThen(decoder.decodeText)
+    }.foldLeft(Future(Queue.empty[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])) {
+      (accumF, next) => accumF flatMap {
+        accum => next map {
+          d => accum.enqueue(d.getOrElse(ValueDecoder.unknownBinary _))
+        }
+      }
+    }
 
-    (names, parsers)
+    parsers.map {
+      decoders => (names, decoders.toIndexedSeq)
+    }
   }
 
-  private[this] def extractRows(rs: SelectResult): List[Row] = {
-    val (fieldNames, fieldParsers) = processFields(rs.fields)
+  private[this] def extractRows(rs: SelectResult): Future[List[Row]] = processFields(rs.fields) map {
+    case (fieldNames, fieldParsers) =>
 
     rs.rows.map(dataRow => new Row(fieldNames, dataRow.data.zip(fieldParsers).map {
-      case (d, p) => if (d == null) null else p(d)
+      case (d, p) => if (d == null) null else p(d, charset).getOrElse(null)
     }))
   }
 
@@ -190,7 +272,7 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
         exec <- execute(name, optionalService = Some(service))
       } yield exec match {
           case CommandCompleteResponse(rows) => OK(rows)
-          case Rows(rows, true) => ResultSet(fieldNames, fieldParsers, rows, customTypes)
+          case Rows(rows, true) => ResultSet(fieldNames, charset, fieldParsers, rows)
         }
       f transform {
         result =>
@@ -208,26 +290,81 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
  * Helper companion object that generates a client from authentication information.
  */
 object Client {
+
+  case class TypeSpecifier(receiveFunction: String, elemOid: Long = 0)
+
+  private[postgres] val defaultTypes = Map(
+    Type.BOOL -> TypeSpecifier("boolrecv"),
+    Type.BYTE_A -> TypeSpecifier("bytearecv"),
+    Type.CHAR -> TypeSpecifier("charrecv"),
+    Type.NAME -> TypeSpecifier("namerecv"),
+    Type.INT_8 -> TypeSpecifier("int8recv"),
+    Type.INT_2 -> TypeSpecifier("int2recv"),
+    Type.INT_4 -> TypeSpecifier("int4recv"),
+    Type.REG_PROC -> TypeSpecifier("regprocrecv"),
+    Type.TEXT -> TypeSpecifier("textrecv"),
+    Type.OID -> TypeSpecifier("oidrecv"),
+    Type.TID -> TypeSpecifier("tidrecv"),
+    Type.XID -> TypeSpecifier("xidrecv"),
+    Type.CID -> TypeSpecifier("cidrecv"),
+    Type.XML -> TypeSpecifier("xml_recv"),
+    Type.POINT -> TypeSpecifier("point_recv"),
+    Type.L_SEG -> TypeSpecifier("lseg_recv"),
+    Type.PATH -> TypeSpecifier("path_recv"),
+    Type.BOX -> TypeSpecifier("box_recv"),
+    Type.POLYGON -> TypeSpecifier("poly_recv"),
+    Type.LINE -> TypeSpecifier("line_recv"),
+    Type.CIDR -> TypeSpecifier("cidr_recv"),
+    Type.FLOAT_4 -> TypeSpecifier("float4recv"),
+    Type.FLOAT_8 -> TypeSpecifier("float8recv"),
+    Type.ABS_TIME -> TypeSpecifier("abstimerecv"),
+    Type.REL_TIME -> TypeSpecifier("reltimerecv"),
+    Type.T_INTERVAL -> TypeSpecifier("tinternalrecv"),
+    Type.UNKNOWN -> TypeSpecifier("unknownrecv"),
+    Type.CIRCLE -> TypeSpecifier("circle_recv"),
+    Type.MONEY -> TypeSpecifier("cash_recv"),
+    Type.MAC_ADDR -> TypeSpecifier("macaddr_recv"),
+    Type.INET -> TypeSpecifier("inet_recv"),
+    Type.BP_CHAR -> TypeSpecifier("bpcharrecv"),
+    Type.VAR_CHAR -> TypeSpecifier("varcharrecv"),
+    Type.DATE -> TypeSpecifier("date_recv"),
+    Type.TIME -> TypeSpecifier("time_recv"),
+    Type.TIMESTAMP -> TypeSpecifier("timestamp_recv"),
+    Type.TIMESTAMP_TZ -> TypeSpecifier("timestamptz_recv"),
+    Type.INTERVAL -> TypeSpecifier("interval_recv"),
+    Type.TIME_TZ -> TypeSpecifier("timetz_recv"),
+    Type.BIT -> TypeSpecifier("bit_recv"),
+    Type.VAR_BIT -> TypeSpecifier("varbit_recv"),
+    Type.NUMERIC -> TypeSpecifier("numeric_recv"),
+    Type.RECORD -> TypeSpecifier("record_recv"),
+    Type.VOID -> TypeSpecifier("void_recv"),
+    Type.UUID -> TypeSpecifier("uuid_recv")
+  )
+
   def apply(
-      host: String,
-      username: String,
-      password: Option[String],
-      database: String,
-      useSsl: Boolean = false,
-      hostConnectionLimit: Int = 1,
-      numRetries: Int = 4,
-      customTypes: Boolean = false): Client = {
+    host: String,
+    username: String,
+    password: Option[String],
+    database: String,
+    useSsl: Boolean = false,
+    hostConnectionLimit: Int = 1,
+    numRetries: Int = 4,
+    customTypes: Boolean = false,
+    customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
+    binaryResults: Boolean = false
+  ): Client = {
     val id = Random.alphanumeric.take(28).mkString
 
     val factory: ServiceFactory[PgRequest, PgResponse] = ClientBuilder()
-      .codec(new PgCodec(username, password, database, id, useSsl = useSsl, customTypes = customTypes))
+      .codec(new PgCodec(username, password, database, id, useSsl = useSsl))
       .hosts(host)
       .hostConnectionLimit(hostConnectionLimit)
       .retries(numRetries)
       .failFast(enabled = true)
       .buildFactory()
 
-    new Client(factory, id)
+    val types = if(!customTypes) Some(defaultTypes) else None
+    new Client(factory, id, types, customReceiveFunctions, binaryResults)
   }
 }
 

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -219,26 +219,27 @@ class BackendMessageParser {
   }
 
   def parseTag(tag: String) : CommandCompleteStatus = {
-    if (tag == "CREATE TABLE") {
-      CreateTable
-    } else if (tag == "DROP TABLE") {
-      DropTable
-    } else if (tag == "DISCARD ALL") {
-      DiscardAll
-    } else {
-      val parts = tag.split(" ")
+    tag match {
+      case "CREATE TABLE" => CreateTable
+      case "CREATE EXTENSION"=> CreateExtension
+      case "CREATE TYPE" => CreateType
+      case "DO" => Do
+      case "DISCARD ALL" => DiscardAll
+      case "DROP TABLE" => DropTable
+      case _ =>
+        val parts = tag.split(" ")
 
-      parts(0) match {
-        case "SELECT" => Select(parts(1).toInt)
-        case "INSERT" => Insert(parts(2).toInt)
-        case "DELETE" => Delete(parts(1).toInt)
-        case "UPDATE" => Update(parts(1).toInt)
-        case "BEGIN"  => Begin
-        case "SAVEPOINT" => Savepoint
-        case "ROLLBACK"  => RollBack
-        case "COMMIT" => Commit
-        case _ => throw new IllegalStateException("Unknown command complete response tag " + tag)
-      }
+        parts(0) match {
+          case "SELECT" => Select(parts(1).toInt)
+          case "INSERT" => Insert(parts(2).toInt)
+          case "DELETE" => Delete(parts(1).toInt)
+          case "UPDATE" => Update(parts(1).toInt)
+          case "BEGIN"  => Begin
+          case "SAVEPOINT" => Savepoint
+          case "ROLLBACK"  => RollBack
+          case "COMMIT" => Commit
+          case _ => throw new IllegalStateException("Unknown command complete response tag " + tag)
+        }
     }
   }
 

--- a/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
@@ -67,6 +67,7 @@ case class Bind(portal: String = Strings.empty, name: String = Strings.empty, fo
     if (formats.isEmpty) {
       builder.writeShort(0)
     } else {
+      builder.writeShort(formats.length.toShort)
       for (format <- formats) {
         builder.writeShort(format.toShort)
       }
@@ -86,6 +87,7 @@ case class Bind(portal: String = Strings.empty, name: String = Strings.empty, fo
     if (resultFormats.isEmpty) {
       builder.writeShort(0)
     } else {
+      builder.writeShort(resultFormats.length.toShort)
       for (format <- resultFormats) {
         builder.writeShort(format.toShort)
       }

--- a/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
@@ -39,6 +39,17 @@ object Buffers {
     buffer.readerIndex(buffer.readerIndex() + count + 1)
     result
   }
+
+  def readBytes(buffer: ChannelBuffer) = {
+    val array = new Array[Byte](buffer.readableBytes())
+    buffer.readBytes(array)
+    array
+  }
+
+  def readString(buffer: ChannelBuffer, charset: Charset) = {
+    val array = readBytes(buffer)
+    new String(array, charset)
+  }
 }
 
 object Md5Encryptor {

--- a/src/test/scala/com/twitter/finagle/postgres/Generators.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/Generators.scala
@@ -1,0 +1,56 @@
+package com.twitter.finagle.postgres
+
+import java.nio.charset.StandardCharsets
+import java.time.{ZonedDateTime, _}
+import java.time.temporal.JulianFields
+import java.util.UUID
+
+import org.scalacheck.{Arbitrary, Gen}
+
+object Generators {
+  //need a more sensible BigDecimal generator, because ScalaCheck goes crazy with it and we can't even stringify them
+  //this will be sufficient to test the decoder
+  implicit val arbBD: Arbitrary[BigDecimal] = Arbitrary(for {
+    precision <- Gen.choose(1, 32)
+    scale <- Gen.choose(-32, 32)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)))
+
+  implicit val arbDate = Arbitrary[LocalDate](for {
+    julian <- Gen.choose(1721060, 5373484)  //Postgres date parser doesn't like dates outside year range 0000-9999
+  } yield LocalDate.now().`with`(JulianFields.JULIAN_DAY, julian))
+
+  implicit val arbTime = Arbitrary[LocalTime](for {
+    usec <- Gen.choose(0L, 24L * 60 * 60 * 1000000 - 1)
+  } yield LocalTime.ofNanoOfDay(usec * 1000))
+
+  implicit val arbTimestamp = Arbitrary[LocalDateTime](for {
+    milli <- Gen.posNum[Long]
+  } yield LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
+
+  implicit val arbTimestampTz = Arbitrary[ZonedDateTime](for {
+    milli <- Gen.posNum[Long]
+  } yield ZonedDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
+
+  implicit val arbUUID = Arbitrary[UUID](Gen.uuid)
+
+  // arbitrary string that only contains valid UTF-8 characters
+  implicit val arbString = {
+    val encoder = StandardCharsets.UTF_8.newEncoder()
+    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => encoder.canEncode(ch))
+    Arbitrary[String](Gen.listOf(chars).map(_.mkString))
+  }
+
+  // postgres has slightly different precision rules, but that doesn't mean the decoder isn't working
+  implicit val arbFloat = Arbitrary[Float](for {
+    precision <- Gen.choose(1, 6)
+    scale <- Gen.choose(-10, 10)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)).toFloat)
+
+  implicit val arbDouble = Arbitrary[Double](for {
+    precision <- Gen.choose(1, 15)
+    scale <- Gen.choose(-20, 20)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)).toDouble)
+}

--- a/src/test/scala/com/twitter/finagle/postgres/Generators.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/Generators.scala
@@ -37,7 +37,7 @@ object Generators {
   // arbitrary string that only contains valid UTF-8 characters
   implicit val arbString = {
     val encoder = StandardCharsets.UTF_8.newEncoder()
-    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => encoder.canEncode(ch))
+    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => ch.toInt != 0 && encoder.canEncode(ch))
     Arbitrary[String](Gen.listOf(chars).map(_.mkString))
   }
 

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -1,0 +1,77 @@
+package com.twitter.finagle.postgres.integration
+
+import java.time.ZoneId
+import java.time.temporal.ChronoField
+
+import com.twitter.finagle.postgres.values.ValueDecoder
+import com.twitter.finagle.postgres.{Client, ResultSet, Spec, Generators}, Generators._
+import com.twitter.util.Await
+import org.jboss.netty.buffer.ChannelBuffers
+import org.scalacheck.Arbitrary
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
+
+  def test[T : Arbitrary](
+    decoder: ValueDecoder[T])(
+    typ: String,
+    toStr: T => String = (t: T) => t.toString,
+    tester: (T, T) => Boolean = (a: T, b: T) => a == b)(
+    implicit client: Client
+  ) = forAll {
+    (t: T) =>
+      //TODO: change this once prepared statements are available
+      val result = Await.result(client.prepareAndQuery(s"SELECT $$1::$typ AS out", t) {
+        row => row.get(0).value.asInstanceOf[T]
+      }).head
+      if(!tester(t, result))
+        fail(s"$t does not match $result")
+  }
+
+  for {
+    binary <- Seq(false, true)
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
+
+    implicit val client = Client(hostPort, user, password, dbname, useSsl, customTypes = true, binaryResults = binary)
+
+    val mode = if(binary) "binary mode" else "text mode"
+
+    s"A $mode postgres client" should {
+      "retrieve the available types from the remote DB" in {
+        val types = Await.result(client.typeMap)
+        assert(types.nonEmpty)
+        assert(types != Client.defaultTypes)
+      }
+    }
+
+    s"Retrieved type map decoders for $mode client" must {
+      "parse varchars" in test(ValueDecoder.String)("varchar")
+      "parse text" in test(ValueDecoder.String)("text")
+      "parse booleans" in test(ValueDecoder.Boolean)("boolean", b => if(b) "t" else "f")
+      "parse shorts" in test(ValueDecoder.Int2)("int2")
+      "parse ints" in test(ValueDecoder.Int4)("int4")
+      "parse longs" in test(ValueDecoder.Int8)("int8")
+      //precision seems to be an issue when postgres parses text floats
+      "parse floats" in test(ValueDecoder.Float4)("numeric::float4")
+      "parse doubles" in test(ValueDecoder.Float8)("numeric::float8")
+      "parse numerics" in test(ValueDecoder.Numeric)("numeric")
+      "parse timestamps" in test(ValueDecoder.Timestamp)(
+        "timestamp",
+        ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse timestamps with time zone" in test(ValueDecoder.TimestampTZ)(
+        "timestamptz",
+        ts => java.sql.Timestamp.from(ts.toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse uuids" in test(ValueDecoder.Uuid)("uuid")
+    }
+
+  }
+}

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -1,62 +1,59 @@
 package com.twitter.finagle.postgres.integration
 
 import java.sql.Timestamp
+import java.time.{ZoneId, ZonedDateTime}
 
 import com.twitter.finagle.postgres.codec.ServerError
-import com.twitter.finagle.postgres.{Row, OK, Spec, Client}
-import com.twitter.util.{Duration, Await}
+import com.twitter.finagle.postgres.{Client, OK, Row, Spec}
+import com.twitter.util.{Await, Duration}
 
 object IntegrationSpec {
-  val pgHostPort = "localhost:5432"
-  val pgUser = "finagle_tester"
-  val pgPassword = "abc123"
-  val pgDbName = "finagle_postgres_test"
-
   val pgTestTable = "finagle_test"
 }
 
 /*
  * Note: For these to work, you need to have:
  *
- * (1) Postgres running locally on port 5432
- * (2) A database called "finagle_postgres_test"
- * (3) A user named "finagle_tester" with a password of "abc123" and full access to the previous DB
+ * (1) An environment variable PG_HOST_PORT which specifies "host:port" of the test server
+ * (2) Environment variables PG_USER and optionally PG_PASSWORD which specify the username and password to the server
+ * (3) An environment variable PG_DBNAME which specifies the test database
  *
- * If these are conditions are met, set the environment variable RUN_PG_INTEGRATION_TESTS to "1" before running pants.
+ * If these are conditions are met, the integration tests will be run.
  *
  * The tests can be run with SSL by also setting the USE_PG_SSL variable to "1".
  *
- * If the previous environment variable is not set, the tests will not be run.
  */
 class IntegrationSpec extends Spec {
-  def postgresAvailable: Boolean = {
-    sys.env.get("RUN_PG_INTEGRATION_TESTS") == Some("1")
-  }
 
-  def useSsl: Boolean = {
-    sys.env.get("USE_PG_SSL") == Some("1")
-  }
+  for {
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
 
-  val queryTimeout = Duration.fromSeconds(2)
 
-  def getClient = {
-    Client(
-      IntegrationSpec.pgHostPort,
-      IntegrationSpec.pgUser,
-      Some(IntegrationSpec.pgPassword),
-      IntegrationSpec.pgDbName,
-      useSsl = useSsl
-    )
-  }
+    val queryTimeout = Duration.fromSeconds(2)
 
-  def cleanDb(client: Client): Unit = {
-    val dropQuery = client.executeUpdate("DROP TABLE IF EXISTS %s".format(IntegrationSpec.pgTestTable))
-    val response = Await.result(dropQuery, queryTimeout)
+    def getClient = {
+      Client(
+        hostPort,
+        user,
+        password,
+        dbname,
+        useSsl = useSsl
+      )
+    }
 
-    response must equal(OK(1))
+    def cleanDb(client: Client): Unit = {
+      val dropQuery = client.executeUpdate("DROP TABLE IF EXISTS %s".format(IntegrationSpec.pgTestTable))
+      val response = Await.result(dropQuery, queryTimeout)
 
-    val createTableQuery = client.executeUpdate(
-      """
+      response must equal(OK(1))
+
+      val createTableQuery = client.executeUpdate(
+        """
         |CREATE TABLE %s (
         | str_field VARCHAR(40),
         | int_field INT,
@@ -65,14 +62,13 @@ class IntegrationSpec extends Spec {
         | bool_field BOOLEAN
         |)
       """.stripMargin.format(IntegrationSpec.pgTestTable))
-    val response2 = Await.result(createTableQuery, queryTimeout)
+      val response2 = Await.result(createTableQuery, queryTimeout)
+      response2 must equal(OK(1))
+    }
 
-    response2 must equal(OK(1))
-  }
-
-  def insertSampleData(client: Client): Unit = {
-    val insertDataQuery = client.executeUpdate(
-      """
+    def insertSampleData(client: Client): Unit = {
+      val insertDataQuery = client.executeUpdate(
+        """
         |INSERT INTO %s VALUES
         | ('hello', 1234, 10.5, '2015-01-08 11:55:12-0800', TRUE),
         | ('hello', 5557, -4.51, '2015-01-08 12:55:12-0800', TRUE),
@@ -80,21 +76,21 @@ class IntegrationSpec extends Spec {
         | ('goodbye', 4567, 15.8, '2015-01-09 16:55:12+0500', FALSE)
       """.stripMargin.format(IntegrationSpec.pgTestTable))
 
-    val response = Await.result(insertDataQuery, queryTimeout)
+      val response = Await.result(insertDataQuery, queryTimeout)
 
-    response must equal(OK(4))
-  }
+      response must equal(OK(4))
+    }
 
-  "A postgres client" should {
-    "insert and select rows" in {
-      if (postgresAvailable) {
+    "A postgres client" should {
+      "insert and select rows" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val selectQuery = client.select(
           "SELECT * FROM %s WHERE str_field='hello' ORDER BY timestamp_field".format(IntegrationSpec.pgTestTable)
-        )(identity)
+        )(
+          identity)
 
         val resultRows = Await.result(selectQuery, queryTimeout)
 
@@ -106,61 +102,76 @@ class IntegrationSpec extends Spec {
         firstRow.getOption("str_field") must equal(Some("hello"))
         firstRow.getOption("int_field") must equal(Some(7787))
         firstRow.getOption("double_field") must equal(Some(-42.51))
-        firstRow.getOption("timestamp_field") must equal(Some(new Timestamp(1387897260000L)))
+        firstRow.getOption("timestamp_field") must equal(Some(
+          ZonedDateTime.ofLocal(new Timestamp(1387897260000L).toLocalDateTime, ZoneId.systemDefault, null).withFixedOffsetZone()
+        ))
         firstRow.getOption("bool_field") must equal(Some(false))
         firstRow.getOption("bad_column") must equal(None)
-      }
-    }
 
-    "execute a select that returns nothing" in {
-      if (postgresAvailable) {
+
+      }
+
+      "execute a select that returns nothing" in {
         val client = getClient
         cleanDb(client)
+
         insertSampleData(client)
 
-        val selectQuery = client.select(
-          "SELECT * FROM %s WHERE str_field='xxxx' ORDER BY timestamp_field".format(IntegrationSpec.pgTestTable)
+        val
+        selectQuery = client.select(
+          "SELECT * FROM %s WHERE str_field='xxxx' ORDER BY timestamp_field".
+            format(
+
+              IntegrationSpec.pgTestTable)
         )(identity)
 
-        val resultRows = Await.result(selectQuery, queryTimeout)
+        val
 
+        resultRows = Await.result(
+          selectQuery, queryTimeout)
         resultRows.size must equal(0)
       }
-    }
 
-    "update a row" in {
-      if (postgresAvailable) {
+
+      "update a row" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val updateQuery = client.executeUpdate(
+
           "UPDATE %s SET str_field='hello_updated' where int_field=4567".format(IntegrationSpec.pgTestTable)
         )
 
-        val response = Await.result(updateQuery, queryTimeout)
+        val response = Await.
+
+          result(updateQuery, queryTimeout)
 
         response must equal(OK(1))
 
         val selectQuery = client.select(
-          "SELECT * FROM %s WHERE str_field='hello_updated'".format(IntegrationSpec.pgTestTable)
-        )(identity)
 
-        val resultRows = Await.result(selectQuery, queryTimeout)
+          "SELECT * FROM %s WHERE str_field='hello_updated'".format(IntegrationSpec.pgTestTable)
+        )(
+
+          identity)
+
+        val
+        resultRows = Await.result(selectQuery, queryTimeout)
 
         resultRows.size must equal(1)
         resultRows(0).getOption("str_field") must equal(Some("hello_updated"))
       }
-    }
 
-    "delete rows" in {
-      if (postgresAvailable) {
+
+      "delete rows" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val updateQuery = client.executeUpdate(
-          "DELETE FROM %s WHERE str_field='hello'".format(IntegrationSpec.pgTestTable)
+          "DELETE FROM %s WHERE str_field='hello'"
+            .format(IntegrationSpec.pgTestTable)
         )
 
         val response = Await.result(updateQuery, queryTimeout)
@@ -173,19 +184,21 @@ class IntegrationSpec extends Spec {
 
         val resultRows = Await.result(selectQuery, queryTimeout)
 
-        resultRows.size must equal(1)
-        resultRows(0).getOption("str_field") must equal(Some("goodbye"))
+        resultRows.size must equal (1)
+        resultRows (0).getOption("str_field") must equal(Some("goodbye"))
       }
-    }
 
-    "select rows via a prepared query" in {
-      if (postgresAvailable) {
+
+      "select rows via a prepared query" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
-        val preparedQuery = client.prepareAndQuery("SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2"
-          .format(IntegrationSpec.pgTestTable), "hello", true)(identity)
+        val preparedQuery = client.prepareAndQuery(
+          "SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2".format(IntegrationSpec.pgTestTable),
+          "hello",
+          true)(identity)
+
         val resultRows = Await.result(
           preparedQuery,
           queryTimeout
@@ -198,14 +211,11 @@ class IntegrationSpec extends Spec {
             row.getOption("bool_field") must equal(Some(true))
         }
       }
-    }
-  
-    "execute an update via a prepared statement" in {
-      if (postgresAvailable) {
+
+      "execute an update via a prepared statement" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
 
         val preparedQuery = client.prepareAndExecute(
           "UPDATE %s SET str_field = $1 where int_field = 4567".format(IntegrationSpec.pgTestTable),
@@ -220,10 +230,9 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(numRows)
       }
-    }
-  
-    "return rows from UPDATE...RETURNING" in {
-      if (postgresAvailable) {
+
+
+      "return rows from UPDATE...RETURNING" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
@@ -239,19 +248,18 @@ class IntegrationSpec extends Spec {
         resultRows.size must equal(1)
         resultRows(0).get[String]("str_field") must equal("hello_updated")
       }
-    }
-  
-    "return rows from DELETE...RETURNING" in {
-      if (postgresAvailable) {
+
+      "return rows from DELETE...RETURNING" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         Await.result(client.prepareAndExecute(
-          s"INSERT INTO ${IntegrationSpec.pgTestTable} VALUES ('delete', 9012, 15.8, '2015-01-09 16:55:12+0500', FALSE)"
+          s"""INSERT INTO ${IntegrationSpec.pgTestTable}
+              VALUES ('delete', 9012, 15.8, '2015-01-09 16:55:12+0500', FALSE)"""
         ))
 
-        val preparedQuery = client.prepareAndQuery(
+        val preparedQuery = client.prepareAndQuery (
           "DELETE FROM %s where int_field = 9012 RETURNING *".format(IntegrationSpec.pgTestTable)
         )(identity)
     
@@ -260,15 +268,12 @@ class IntegrationSpec extends Spec {
         resultRows.size must equal(1)
         resultRows(0).get[String]("str_field") must equal("delete")
       }
-    }
-  
-    "execute an UPDATE...RETURNING that updates nothing" in {
-      if (postgresAvailable) {
+
+
+      "execute an UPDATE...RETURNING that updates nothing" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
-
         val preparedQuery = client.prepareAndQuery(
           "UPDATE %s SET str_field = $1 where str_field = $2 RETURNING *".format(IntegrationSpec.pgTestTable),
           "hello_updated",
@@ -279,14 +284,12 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(0)
       }
-    }
-  
-    "execute a DELETE...RETURNING that deletes nothing" in {
-      if (postgresAvailable) {
+
+      "execute a DELETE...RETURNING that deletes nothing" in {
+
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
 
         val preparedQuery = client.prepareAndQuery(
           "DELETE FROM %s WHERE str_field=$1".format(IntegrationSpec.pgTestTable),
@@ -294,37 +297,32 @@ class IntegrationSpec extends Spec {
         )(identity)
     
         val resultRows = Await.result(preparedQuery)
-
         resultRows.size must equal(0)
       }
-    }
 
-    // this test will fail because the test DB user doesn't have permission
-    "create an extension using CREATE EXTENSION" ignore {
-      if(postgresAvailable) {
-        val client = getClient
-        val result = client.prepareAndExecute("CREATE EXTENSION hstore")
-        Await.result(result)
+      // this test will fail if the test DB user doesn't have permission
+      "create an extension using CREATE EXTENSION" in {
+        if(user == "postgres") {
+          val client = getClient
+          val result = client.prepareAndExecute("CREATE EXTENSION hstore")
+          Await.result(result)
+        }
       }
-    }
 
-    "support multi-statement DDL" in {
-      if(postgresAvailable) {
+      "support multi-statement DDL" in {
         val client = getClient
-        val result = client.query(
-          """
-            |CREATE TABLE multi_one(id integer);
-            |CREATE TABLE multi_two(id integer);
-            |DROP TABLE multi_one;
-            |DROP TABLE multi_two;
+        val result = client.query("""
+          |CREATE TABLE multi_one(id integer);
+          |CREATE TABLE multi_two(id integer);
+          |DROP TABLE multi_one;
+          |DROP TABLE multi_two;
           """.stripMargin)
         Await.result(result)
       }
-    }
 
-    "throw a ServerError" when {
-      "query has error" in {
-        if (postgresAvailable) {
+
+      "throw a ServerError" when {
+        "query has error" in {
           val client = getClient
           cleanDb(client)
 
@@ -336,15 +334,16 @@ class IntegrationSpec extends Spec {
             Await.result(selectQuery, queryTimeout)
           }
         }
-      }
 
-      "prepared query is missing parameters" in {
-        if (postgresAvailable) {
+        "prepared query is missing parameters" in {
+
           val client = getClient
           cleanDb(client)
 
-          val preparedQuery = client.prepareAndQuery("SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2"
-            .format(IntegrationSpec.pgTestTable), "hello")(identity)
+          val preparedQuery = client.prepareAndQuery(
+            "SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2".format(IntegrationSpec.pgTestTable),
+            "hello"
+          )(identity)
 
           a [ServerError] must be thrownBy {
             Await.result(
@@ -352,8 +351,10 @@ class IntegrationSpec extends Spec {
               queryTimeout
             )
           }
+
         }
       }
     }
+
   }
 }

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -70,6 +70,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
         (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
       )
       "parse uuids" in test(ValueDecoder.Uuid)("uuid_send", "uuid")
+      "parse dates" in test(ValueDecoder.Date)("date_send", "date")
     }
   }
 }

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -1,46 +1,75 @@
 package com.twitter.finagle.postgres.values
 
-import java.util.{Date, TimeZone, UUID}
+import java.time._
+import java.time.temporal.{ChronoField, JulianFields}
 
-import com.twitter.finagle.postgres.Spec
+import com.twitter.finagle.postgres.{Client, Generators, ResultSet, Spec}, Generators._
+import com.twitter.util.Await
+import org.jboss.netty.buffer.ChannelBuffers
+import org.scalacheck.Arbitrary
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class ValuesSpec extends Spec {
-  "A StringValueParser" should {
-    "parse varchars" in {
-      StringValueParser.parseVarChar(StringValueEncoder.encode("someTestString ")) must equal(Value("someTestString "))
-    }
+class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
 
-    "parse booleans" in {
-      StringValueParser.parseBoolean(StringValueEncoder.encode("t")) must equal(Value(true))
-      StringValueParser.parseBoolean(StringValueEncoder.encode("f")) must equal(Value(false))
-    }
 
-    "parse numbers" in {
-      StringValueParser.parseInt2(StringValueEncoder.encode(555)) must equal(Value(555))
-      StringValueParser.parseInt8(StringValueEncoder.encode(1234567891011L)) must equal(Value(1234567891011L))
-      StringValueParser.parseFloat4(StringValueEncoder.encode(-10.17)) must equal(Value(-10.17f))
-      StringValueParser.parseFloat8(StringValueEncoder.encode(1312310.17881919)) must equal(Value(1312310.17881919))
-    }
+  def test[T : Arbitrary](
+    decoder: ValueDecoder[T])(
+    send: String,
+    typ: String,
+    toStr: T => String = (t: T) => t.toString,
+    tester: (T, T) => Boolean = (a: T, b: T) => a == b)(
+    implicit client: Client
+  ) = forAll {
+    (t: T) =>
+      //TODO: change this once prepared statements are available
+      val escaped = toStr(t).replaceAllLiterally("'", "\\'")
+      val ResultSet(List(binaryRow)) = Await.result(client.query(s"SELECT $send('$escaped'::$typ) AS out"))
+      val ResultSet(List(textRow)) = Await.result(client.query(s"SELECT CAST('$escaped'::$typ AS text) AS out"))
+      val bytes = binaryRow.get[Array[Byte]]("out")
+      val textString = textRow.get[String]("out")
+      val binaryOut = decoder.decodeBinary(ChannelBuffers.wrappedBuffer(bytes), client.charset).get.value
+      val textOut = decoder.decodeText(textString).get.value
 
-    "parse a timestamp without a timezone" in {
-      val timestamp = StringValueParser.parseTimestamp(StringValueEncoder.encode("2015-01-08 14:55:12.123")).value
+      if(!tester(t, binaryOut))
+        fail(s"binary: $t does not match $binaryOut")
 
-      // Java interprets timestamp as being in local timezone; need to adjust to get epoch time
-      timestamp.getTime must equal(1420728912123L - TimeZone.getDefault.getOffset(1420728912123L))
-    }
+      if(!tester(t, textOut))
+        fail(s"text: $t does not match $textOut")
+  }
 
-    "parse timestamps with timezones" in {
-      val timestamp = StringValueParser.parseTimestampTZ(StringValueEncoder.encode("2015-01-08 14:55:12.123-05")).value
-      // Note: Milliseconds in timestamp are ignored
-      timestamp.getTime must equal(1420746912000L)
 
-      val timestamp2 = StringValueParser.parseTimestampTZ(StringValueEncoder.encode("2015-01-08 14:55:12+0800")).value
-      timestamp2.getTime must equal(1420700112000L)
-    }
-
-    "parse UUIDs" in {
-      val uuid = StringValueParser.parseUUID(StringValueEncoder.encode("deadbeef-dead-dead-beef-deaddeadbeef")).value
-      uuid must equal(UUID.fromString("deadbeef-dead-dead-beef-deaddeadbeef"))
+  for {
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
+    implicit val client = Client(hostPort, user, password, dbname, useSsl)
+    "ValueDecoders" should {
+      "parse varchars" in test(ValueDecoder.String)("varcharsend", "varchar")
+      "parse text" in test(ValueDecoder.String)("textsend", "text")
+      "parse booleans" in test(ValueDecoder.Boolean)("boolsend", "boolean", b => if(b) "t" else "f")
+      "parse shorts" in test(ValueDecoder.Int2)("int2send", "int2")
+      "parse ints" in test(ValueDecoder.Int4)("int4send", "int4")
+      "parse longs" in test(ValueDecoder.Int8)("int8send", "int8")
+      //precision seems to be an issue when postgres parses text floats
+      "parse floats" in test(ValueDecoder.Float4)("float4send", "numeric")
+      "parse doubles" in test(ValueDecoder.Float8)("float8send", "numeric")
+      "parse numerics" in test(ValueDecoder.Numeric)("numeric_send", "numeric")
+      "parse timestamps" in test(ValueDecoder.Timestamp)(
+        "timestamp_send",
+        "timestamp",
+        ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse timestamps with time zone" in test(ValueDecoder.TimestampTZ)(
+        "timestamptz_send",
+        "timestamptz",
+        ts => java.sql.Timestamp.from(ts.toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse uuids" in test(ValueDecoder.Uuid)("uuid_send", "uuid")
     }
   }
 }


### PR DESCRIPTION
This commit changes how values are decoded internally. It introduces the `ValueDecoder` trait, which is responsible for decoding a value from either text or binary using a particular strategy.

Additionally, OIDs are now used to map to the name of the postgres receive function for a type, which is a reliable way of deciding how the value should be decoded. These receive functions are then mapped to ValueDecoders.  This change allows for cusom value decoders to be specified, and also allows for the remote database to be queried for its types; custom types may be present with a non-fixed OID, but which use existing receive functions.  Thus, type handling is more robust against postgres use cases.

Changes to the user-facing API:
- Client.apply now accepts additional optional arguments:
  - `customReceiveFunctions` which allows for specifying a `PartialFunction` that maps receive function names to `ValueDecoder`s
  - `binaryResults` which allows specifying that the client should ask the server for results in binary format (which is more robust and performant than text)
- Timestamps now use appropriate `java.time` representations by default:
  - `java.time.LocalDateTime` for timestamp
  - `java.time.ZonedDateTime` for timestamp with time zone
  - `java.time.LocalDate` for date

Compatibility changes:
- Java 8 is now required (since `java.time` is used)

The integration tests have also been changed to use an environment-configurable Postgres instance, rather than a hard-coded one.  This will allow the integration tests to actually run in travis-ci.

Tests also now use ScalaCheck where possible.

There are also a few fixes for bugs which didn't become apparent until binary mode was possible.
