### PR TITLE
Close service when prepared query can't be parsed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val publishSettings = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
-lazy val root = project.in(file("."))
+lazy val `finagle-postgres` = project.in(file("."))
   .settings(moduleName := "finagle-postgres")
   .settings(allSettings)
   .configs(IntegrationTest)

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -81,6 +81,8 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
       service =>
         parse(sql, Some(service)).map { name =>
           new PreparedStatementImpl(name, service)
+        }.onFailure {
+          err => service.close()
         }
     }
 

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -338,6 +338,15 @@ class IntegrationSpec extends Spec {
         }
       }
 
+      "query in a prepared statement has an error" in {
+        if(postgresAvailable) {
+          val client = getClient
+          a [ServerError] must be thrownBy {
+            Await.result(client.prepareAndQuery("Garbage query")(identity))
+          }
+        }
+      }
+
       "prepared query is missing parameters" in {
         if (postgresAvailable) {
           val client = getClient


### PR DESCRIPTION
This fixes an issue wherein the service isn't closed when the parse
phase of a prepared statement fails.  This causes that connection to
hang.  Instead, the parse failure should cause the service to be closed
(just as the successful completion of the query closes the service, and
the failure at any other point during the process does the same).
