### PR TITLE
0.2.0 - Type safe parameter encoding and value decoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ services:
   - postgresql
 
 env:
-  - PG_HOST_PORT=localhost:5432
-  - PG_USER=postgres
-  - PG_DBNAME=finagle_postgres_test
+  - PG_HOST_PORT=localhost:5432 PG_USER=postgres PG_DBNAME=finagle_postgres_test
 
 before_script:
   - createdb -U postgres finagle_postgres_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,18 @@ scala:
   - 2.11.7
 
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
+
+services:
+  - postgresql
+
+env:
+  - PG_HOST_PORT=localhost:5432
+  - PG_USER=postgres
+  - PG_DBNAME=finagle_postgres_test
+
+before_script:
+  - createdb -U postgres finagle_postgres_test
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,12 @@ script:
 after_success:
   - sbt coveralls
 
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,8 @@ val baseSettings = Seq(
     "com.twitter" %% "finagle-core" % "6.35.0",
     "junit" % "junit" % "4.7" % "test,it",
     "org.scalatest" %% "scalatest" % "2.2.5" % "test,it",
-    "org.mockito" % "mockito-all" % "1.9.5" % "test,it"
+    "org.mockito" % "mockito-all" % "1.9.5" % "test,it",
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test,it"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.1.1-SNAPSHOT",
+  version := "0.2.0-SNAPSHOT",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val publishSettings = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
-lazy val root = project.in(file("."))
+lazy val `finagle-postgres` = project.in(file("."))
   .settings(moduleName := "finagle-postgres")
   .settings(allSettings)
   .configs(IntegrationTest)

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -208,6 +208,14 @@ class Client(
     }
   }
 
+  /**
+    * Close the underlying connection pool and make this Client eternally down
+    * @return
+    */
+  def close(): Future[Unit] = {
+    factory.close()
+  }
+
   private[this] def sendQuery[T](sql: String)(handler: PartialFunction[PgResponse, Future[T]]) = {
     send(PgRequest(new Query(sql)))(handler)
   }

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -1,26 +1,91 @@
 package com.twitter.finagle.postgres
 
+import java.nio.charset.{Charset, StandardCharsets}
+
 import com.twitter.finagle.{Service, ServiceFactory}
 import com.twitter.finagle.builder.ClientBuilder
-import com.twitter.finagle.postgres.codec.{CustomOIDProxy, PgCodec, Errors}
+import com.twitter.finagle.postgres.codec.{Errors, PgCodec}
 import com.twitter.finagle.postgres.messages._
-import com.twitter.finagle.postgres.values.{StringValueEncoder, ValueParser, Value}
+import com.twitter.finagle.postgres.values._
 import com.twitter.logging.Logger
-import com.twitter.util.Future
-
+import com.twitter.util.{Future, Return, Throw, Try}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.jboss.netty.buffer.ChannelBuffer
 
+import scala.collection.immutable.Queue
 import scala.util.Random
 
 /*
  * A Finagle client for communicating with Postgres.
  */
-class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
+class Client(
+  factory: ServiceFactory[PgRequest, PgResponse],
+  id:String,
+  types: Option[Map[Int, Client.TypeSpecifier]] = None,
+  customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
+  binaryResults: Boolean = false
+) {
   private[this] val counter = new AtomicInteger(0)
-  private[this] lazy val customTypes = CustomOIDProxy.serviceOIDMap(id)
   private[this] val logger = Logger(getClass.getName)
+  private val resultFormats = if(binaryResults) Seq(1) else Seq(0)
+
+  val charset = StandardCharsets.UTF_8
+
+  private def retrieveTypeMap() = {
+    //get a mapping of OIDs to the name of the receive function for all types in the remote DB.
+    //typreceive is the most reliable way to determine how a type should be decoded
+    val customTypesQuery =
+      """
+       |SELECT DISTINCT
+       |  CAST(t.typname AS text) AS type,
+       |  CAST(t.oid AS integer) AS oid,
+       |  CAST(t.typreceive AS text) AS typreceive,
+       |  CAST(t.typelem AS integer) AS typelem
+       |FROM           pg_type t
+       |WHERE          CAST(t.typreceive AS text) <> '-'
+     """.stripMargin
+
+    val serviceF = factory.apply
+
+    val bootstrapTypes = Map(
+      Type.INT_4 -> ValueDecoder.Int4,
+      Type.TEXT -> ValueDecoder.String
+    )
+
+    val customTypesResult = for {
+      service <- serviceF
+      response <- service.apply(new PgRequest(new Query(customTypesQuery)))
+    } yield response match {
+      case SelectResult(fields, rows) =>
+        val rowValues = rows.map {
+          row =>
+            row.data.zip(fields).map {
+              case (buf, field) =>
+                val decoder = bootstrapTypes(field.dataType)
+                if(field.format == 0)
+                  decoder.decodeText(Buffers.readString(buf, charset)).getOrElse(null)
+                else
+                  decoder.decodeBinary(buf, charset).getOrElse(null)
+            }
+        }
+        val fieldNames = fields.map(_.name)
+        rowValues.map(row => new Row(fieldNames, row)).map {
+          row => row.get[Int]("oid") -> Client.TypeSpecifier(row.get[String]("typreceive"), row.get[Int]("typelem"))
+        }.toMap
+    }
+
+    customTypesResult.ensure {
+      serviceF.foreach(_.close())
+    }
+
+    customTypesResult
+  }
+
+  val typeMap = types.map(Future(_)).getOrElse(retrieveTypeMap())
+
+  val decoders = customReceiveFunctions orElse ValueDecoder.decoders
+
 
   /*
    * Execute some actions inside of a transaction using a single connection
@@ -47,7 +112,9 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
    * Issue an arbitrary SQL query and get the response.
    */
   def query(sql: String): Future[QueryResponse] = sendQuery(sql) {
-    case SelectResult(fields, rows) => Future(ResultSet(fields, rows, customTypes))
+    case SelectResult(fields, rows) => processFields(fields).map {
+      case (names, parsers) => ResultSet(names, charset, parsers, rows)
+    }
     case CommandCompleteResponse(affected) => Future(OK(affected))
   }
 
@@ -68,9 +135,9 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   /*
    * Run a single SELECT query and wrap the results with the provided function.
    */
-  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql) map {
+  def select[T](sql: String)(f: Row => T): Future[Seq[T]] = fetch(sql).flatMap {
     rs =>
-      extractRows(rs).map(f)
+      extractRows(rs).map(_.map(f))
   }
 
   /*
@@ -99,15 +166,15 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
     val preparedStatement = factory.apply().flatMap {
       service =>
         parse(sql, Some(service)).map { name =>
-	  new PreparedStatementImpl(name, service)
-	}
+          new PreparedStatementImpl(name, service)
+        }
     }
 
     preparedStatement.flatMap {
       statement =>
         statement.exec(params: _*).ensure {
-	  statement.closeService
-	}
+          statement.closeService
+        }
     } map {
       case OK(count) => count
     }
@@ -131,7 +198,7 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
       name: String,
       params: Seq[ChannelBuffer] = Seq(),
       optionalService: Option[Service[PgRequest, PgResponse]] = None): Future[Unit] = {
-    send(PgRequest(Bind(portal = name, name = name, params = params), flush = true), optionalService) {
+    send(PgRequest(Bind(portal = name, name = name, params = params, resultFormats = resultFormats), flush = true), optionalService) {
       case BindCompletedResponse => Future.value(())
     }
   }
@@ -139,11 +206,11 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   private[this] def describe(
       name: String,
       optionalService: Option[Service[PgRequest, PgResponse]] = None
-    ): Future[(IndexedSeq[String], IndexedSeq[ChannelBuffer => Value[Any]])] = {
+    ): Future[(IndexedSeq[String], IndexedSeq[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])] =
     send(PgRequest(Describe(portal = true, name = name), flush = true), optionalService) {
-      case RowDescriptions(fields) => Future.value(processFields(fields))
+      case RowDescriptions(fields) => processFields(fields)
     }
-  }
+
 
   private[this] def execute(
       name: String,
@@ -180,18 +247,33 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
   }
 
   private[this] def processFields(
-      fields: IndexedSeq[Field]): (IndexedSeq[String], IndexedSeq[ChannelBuffer => Value[Any]]) = {
+      fields: IndexedSeq[Field]): Future[(IndexedSeq[String], IndexedSeq[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])] = {
     val names = fields.map(f => f.name)
-    val parsers = fields.map(f => ValueParser.parserOf(f.format, f.dataType, customTypes))
+    val parsers = fields.toList.map {
+      f => for {
+        types <- typeMap
+      } yield for {
+        Client.TypeSpecifier(recv, elem) <- types.get(f.dataType)
+        decoder <- decoders.lift.apply(recv)
+      } yield if(f.format != 0) (decoder.decodeBinary _).tupled else (Buffers.readString _).tupled.andThen(decoder.decodeText)
+    }.foldLeft(Future(Queue.empty[((ChannelBuffer, Charset)) => Try[Value[T]] forSome {type T}])) {
+      (accumF, next) => accumF flatMap {
+        accum => next map {
+          d => accum.enqueue(d.getOrElse(ValueDecoder.unknownBinary _))
+        }
+      }
+    }
 
-    (names, parsers)
+    parsers.map {
+      decoders => (names, decoders.toIndexedSeq)
+    }
   }
 
-  private[this] def extractRows(rs: SelectResult): List[Row] = {
-    val (fieldNames, fieldParsers) = processFields(rs.fields)
+  private[this] def extractRows(rs: SelectResult): Future[List[Row]] = processFields(rs.fields) map {
+    case (fieldNames, fieldParsers) =>
 
     rs.rows.map(dataRow => new Row(fieldNames, dataRow.data.zip(fieldParsers).map {
-      case (d, p) => if (d == null) null else p(d)
+      case (d, p) => if (d == null) null else p(d, charset).getOrElse(null)
     }))
   }
 
@@ -211,7 +293,7 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
         exec <- execute(name, optionalService = Some(service))
       } yield exec match {
           case CommandCompleteResponse(rows) => OK(rows)
-          case Rows(rows, true) => ResultSet(fieldNames, fieldParsers, rows, customTypes)
+          case Rows(rows, true) => ResultSet(fieldNames, charset, fieldParsers, rows)
         }
       f transform {
         result =>
@@ -229,26 +311,81 @@ class Client(factory: ServiceFactory[PgRequest, PgResponse], id:String) {
  * Helper companion object that generates a client from authentication information.
  */
 object Client {
+
+  case class TypeSpecifier(receiveFunction: String, elemOid: Long = 0)
+
+  private[postgres] val defaultTypes = Map(
+    Type.BOOL -> TypeSpecifier("boolrecv"),
+    Type.BYTE_A -> TypeSpecifier("bytearecv"),
+    Type.CHAR -> TypeSpecifier("charrecv"),
+    Type.NAME -> TypeSpecifier("namerecv"),
+    Type.INT_8 -> TypeSpecifier("int8recv"),
+    Type.INT_2 -> TypeSpecifier("int2recv"),
+    Type.INT_4 -> TypeSpecifier("int4recv"),
+    Type.REG_PROC -> TypeSpecifier("regprocrecv"),
+    Type.TEXT -> TypeSpecifier("textrecv"),
+    Type.OID -> TypeSpecifier("oidrecv"),
+    Type.TID -> TypeSpecifier("tidrecv"),
+    Type.XID -> TypeSpecifier("xidrecv"),
+    Type.CID -> TypeSpecifier("cidrecv"),
+    Type.XML -> TypeSpecifier("xml_recv"),
+    Type.POINT -> TypeSpecifier("point_recv"),
+    Type.L_SEG -> TypeSpecifier("lseg_recv"),
+    Type.PATH -> TypeSpecifier("path_recv"),
+    Type.BOX -> TypeSpecifier("box_recv"),
+    Type.POLYGON -> TypeSpecifier("poly_recv"),
+    Type.LINE -> TypeSpecifier("line_recv"),
+    Type.CIDR -> TypeSpecifier("cidr_recv"),
+    Type.FLOAT_4 -> TypeSpecifier("float4recv"),
+    Type.FLOAT_8 -> TypeSpecifier("float8recv"),
+    Type.ABS_TIME -> TypeSpecifier("abstimerecv"),
+    Type.REL_TIME -> TypeSpecifier("reltimerecv"),
+    Type.T_INTERVAL -> TypeSpecifier("tinternalrecv"),
+    Type.UNKNOWN -> TypeSpecifier("unknownrecv"),
+    Type.CIRCLE -> TypeSpecifier("circle_recv"),
+    Type.MONEY -> TypeSpecifier("cash_recv"),
+    Type.MAC_ADDR -> TypeSpecifier("macaddr_recv"),
+    Type.INET -> TypeSpecifier("inet_recv"),
+    Type.BP_CHAR -> TypeSpecifier("bpcharrecv"),
+    Type.VAR_CHAR -> TypeSpecifier("varcharrecv"),
+    Type.DATE -> TypeSpecifier("date_recv"),
+    Type.TIME -> TypeSpecifier("time_recv"),
+    Type.TIMESTAMP -> TypeSpecifier("timestamp_recv"),
+    Type.TIMESTAMP_TZ -> TypeSpecifier("timestamptz_recv"),
+    Type.INTERVAL -> TypeSpecifier("interval_recv"),
+    Type.TIME_TZ -> TypeSpecifier("timetz_recv"),
+    Type.BIT -> TypeSpecifier("bit_recv"),
+    Type.VAR_BIT -> TypeSpecifier("varbit_recv"),
+    Type.NUMERIC -> TypeSpecifier("numeric_recv"),
+    Type.RECORD -> TypeSpecifier("record_recv"),
+    Type.VOID -> TypeSpecifier("void_recv"),
+    Type.UUID -> TypeSpecifier("uuid_recv")
+  )
+
   def apply(
-      host: String,
-      username: String,
-      password: Option[String],
-      database: String,
-      useSsl: Boolean = false,
-      hostConnectionLimit: Int = 1,
-      numRetries: Int = 4,
-      customTypes: Boolean = false): Client = {
+    host: String,
+    username: String,
+    password: Option[String],
+    database: String,
+    useSsl: Boolean = false,
+    hostConnectionLimit: Int = 1,
+    numRetries: Int = 4,
+    customTypes: Boolean = false,
+    customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
+    binaryResults: Boolean = false
+  ): Client = {
     val id = Random.alphanumeric.take(28).mkString
 
     val factory: ServiceFactory[PgRequest, PgResponse] = ClientBuilder()
-      .codec(new PgCodec(username, password, database, id, useSsl = useSsl, customTypes = customTypes))
+      .codec(new PgCodec(username, password, database, id, useSsl = useSsl))
       .hosts(host)
       .hostConnectionLimit(hostConnectionLimit)
       .retries(numRetries)
       .failFast(enabled = true)
       .buildFactory()
 
-    new Client(factory, id)
+    val types = if(!customTypes) Some(defaultTypes) else None
+    new Client(factory, id, types, customReceiveFunctions, binaryResults)
   }
 }
 

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -1,6 +1,10 @@
 package com.twitter.finagle.postgres
 
 import java.nio.charset.{Charset, StandardCharsets}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.immutable.Queue
+import scala.util.Random
 
 import com.twitter.finagle.{Service, ServiceFactory}
 import com.twitter.finagle.builder.ClientBuilder
@@ -9,12 +13,10 @@ import com.twitter.finagle.postgres.messages._
 import com.twitter.finagle.postgres.values._
 import com.twitter.logging.Logger
 import com.twitter.util.{Future, Return, Throw, Try}
-import java.util.concurrent.atomic.AtomicInteger
-
 import org.jboss.netty.buffer.ChannelBuffer
 
-import scala.collection.immutable.Queue
-import scala.util.Random
+import scala.language.implicitConversions
+
 
 /*
  * A Finagle client for communicating with Postgres.
@@ -24,11 +26,13 @@ class Client(
   id:String,
   types: Option[Map[Int, Client.TypeSpecifier]] = None,
   customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
-  binaryResults: Boolean = false
+  binaryResults: Boolean = false,
+  binaryParams: Boolean = false
 ) {
   private[this] val counter = new AtomicInteger(0)
   private[this] val logger = Logger(getClass.getName)
   private val resultFormats = if(binaryResults) Seq(1) else Seq(0)
+  private val paramFormats = if(binaryParams) Seq(1) else Seq(0)
 
   val charset = StandardCharsets.UTF_8
 
@@ -82,9 +86,16 @@ class Client(
     customTypesResult
   }
 
-  val typeMap = types.map(Future(_)).getOrElse(retrieveTypeMap())
+  private[postgres] val typeMap = types.map(Future(_)).getOrElse(retrieveTypeMap())
 
-  val decoders = customReceiveFunctions orElse ValueDecoder.decoders
+  // The OIDs to be used when sending parameters for each function
+  private[postgres] val encodeOids = typeMap.map {
+    tm => tm.toIndexedSeq.map {
+      case (oid, Client.TypeSpecifier(receiveFn, elemOid)) => receiveFn -> oid
+    }.groupBy(_._1).mapValues(_.map(_._2).min)
+  }
+
+  private[postgres] val decoders = customReceiveFunctions orElse ValueDecoder.decoders
 
 
   /*
@@ -143,11 +154,18 @@ class Client(
   /*
    * Issue a single, prepared SELECT query and wrap the response rows with the provided function.
    */
-  def prepareAndQuery[T](sql: String, params: Any*)(f: Row => T): Future[Seq[T]] = {
+  def prepareAndQuery[T](sql: String, params: Param[_]*)(f: Row => T): Future[Seq[T]] = {
     val preparedStatement = factory.apply().flatMap {
       service =>
-        parse(sql, Some(service)).map { name =>
+        parse(sql, Some(service), params: _*).map { name =>
           new PreparedStatementImpl(name, service)
+        }.rescue {
+          case err => sync(Some(service)).flatMap {
+            _ =>
+              service.close().flatMap {
+                _ => Future.exception(err)
+              }
+          }
         }
     }
 
@@ -162,11 +180,18 @@ class Client(
   /*
    * Issue a single, prepared arbitrary query without an expected result set, and provide the affected row count
    */
-  def prepareAndExecute(sql: String, params: Any*):Future[Int] = {
+  def prepareAndExecute(sql: String, params: Param[_]*):Future[Int] = {
     val preparedStatement = factory.apply().flatMap {
       service =>
-        parse(sql, Some(service)).map { name =>
+        parse(sql, Some(service), params: _*).map { name =>
           new PreparedStatementImpl(name, service)
+        }.rescue {
+          case err => sync(Some(service)).flatMap {
+            _ =>
+              service.close().flatMap {
+                _ => Future.exception(err)
+              }
+          }
         }
     }
 
@@ -186,11 +211,22 @@ class Client(
 
   private[this] def parse(
       sql: String,
-      optionalService: Option[Service[PgRequest, PgResponse]] = None): Future[String] = {
+      optionalService: Option[Service[PgRequest, PgResponse]],
+      params: Param[_]*): Future[String] = {
     val name = genName()
 
-    send(PgRequest(Parse(name, sql), flush = true), optionalService) {
-      case ParseCompletedResponse => Future.value(name)
+    val paramTypes = encodeOids.map {
+      oidMap => params.map {
+        param => oidMap.getOrElse(param.encoder.recvFunction, 0)
+      }
+    }
+
+    paramTypes.flatMap {
+      types =>
+        val req = Parse(name, sql, types)
+        send(PgRequest(req, flush = true), optionalService) {
+          case ParseCompletedResponse => Future.value(name)
+        }
     }
   }
 
@@ -198,7 +234,16 @@ class Client(
       name: String,
       params: Seq[ChannelBuffer] = Seq(),
       optionalService: Option[Service[PgRequest, PgResponse]] = None): Future[Unit] = {
-    send(PgRequest(Bind(portal = name, name = name, params = params, resultFormats = resultFormats), flush = true), optionalService) {
+
+    val req =  Bind(
+      portal = name,
+      name = name,
+      formats = paramFormats,
+      params = params,
+      resultFormats = resultFormats
+    )
+
+    send(PgRequest(req, flush = true), optionalService) {
       case BindCompletedResponse => Future.value(())
     }
   }
@@ -282,13 +327,19 @@ class Client(
       service: Service[PgRequest, PgResponse]) extends PreparedStatement {
     def closeService = service.close()
 
-    override def fire(params: Any*): Future[QueryResponse] = {
-      val binaryParams = params.map {
-        p => StringValueEncoder.encode(p)
+    override def fire(params: Param[_]*): Future[QueryResponse] = {
+      val paramBuffers = if(binaryParams) {
+        params.map {
+          p => p.encodeBinary(StandardCharsets.UTF_8)
+        }
+      } else {
+        params.map {
+          p => p.encodeText(StandardCharsets.UTF_8)
+        }
       }
 
       val f = for {
-        _ <- bind(name, binaryParams, Some(service))
+        _ <- bind(name, paramBuffers, Some(service))
         (fieldNames, fieldParsers) <- describe(name, Some(service))
         exec <- execute(name, optionalService = Some(service))
       } yield exec match {
@@ -372,7 +423,8 @@ object Client {
     numRetries: Int = 4,
     customTypes: Boolean = false,
     customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome {type T}] = { case "noop" => ValueDecoder.Unknown },
-    binaryResults: Boolean = false
+    binaryResults: Boolean = false,
+    binaryParams: Boolean = false
   ): Client = {
     val id = Random.alphanumeric.take(28).mkString
 
@@ -385,7 +437,7 @@ object Client {
       .buildFactory()
 
     val types = if(!customTypes) Some(defaultTypes) else None
-    new Client(factory, id, types, customReceiveFunctions, binaryResults)
+    new Client(factory, id, types, customReceiveFunctions, binaryResults, binaryParams)
   }
 }
 
@@ -393,18 +445,27 @@ object Client {
  * A query that supports parameter substitution. Can help prevent SQL injection attacks.
  */
 trait PreparedStatement {
-  def fire(params: Any*): Future[QueryResponse]
+  def fire(params: Param[_]*): Future[QueryResponse]
 
-  def exec(params: Any*): Future[OK] = fire(params: _*) map {
+  def exec(params: Param[_]*): Future[OK] = fire(params: _*) map {
     case ok: OK => ok
     case ResultSet(_) => throw Errors.client("Update query expected")
   }
 
-  def select[T](params: Any*)(f: Row => T): Future[Seq[T]] = fire(params: _*) map {
+  def select[T](params: Param[_]*)(f: Row => T): Future[Seq[T]] = fire(params: _*) map {
     case ResultSet(rows) => rows.map(f)
     case OK(_) => Seq.empty[Row].map(f)
   }
 
-  def selectFirst[T](params: Any*)(f: Row => T): Future[Option[T]] =
+  def selectFirst[T](params: Param[_]*)(f: Row => T): Future[Option[T]] =
     select[T](params:_*)(f) flatMap { rows => Future.value(rows.headOption) }
+}
+
+case class Param[T](value: T)(implicit val encoder: ValueEncoder[T]) {
+  def encodeText(charset: Charset = StandardCharsets.UTF_8) = ValueEncoder.encodeText(value, encoder, charset)
+  def encodeBinary(charset: Charset = StandardCharsets.UTF_8) = ValueEncoder.encodeBinary(value, encoder, charset)
+}
+
+object Param {
+  implicit def convert[T : ValueEncoder](t: T): Param[T] = Param(t)
 }

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -219,26 +219,27 @@ class BackendMessageParser {
   }
 
   def parseTag(tag: String) : CommandCompleteStatus = {
-    if (tag == "CREATE TABLE") {
-      CreateTable
-    } else if (tag == "DROP TABLE") {
-      DropTable
-    } else if (tag == "DISCARD ALL") {
-      DiscardAll
-    } else {
-      val parts = tag.split(" ")
+    tag match {
+      case "CREATE TABLE" => CreateTable
+      case "CREATE EXTENSION"=> CreateExtension
+      case "CREATE TYPE" => CreateType
+      case "DO" => Do
+      case "DISCARD ALL" => DiscardAll
+      case "DROP TABLE" => DropTable
+      case _ =>
+        val parts = tag.split(" ")
 
-      parts(0) match {
-        case "SELECT" => Select(parts(1).toInt)
-        case "INSERT" => Insert(parts(2).toInt)
-        case "DELETE" => Delete(parts(1).toInt)
-        case "UPDATE" => Update(parts(1).toInt)
-        case "BEGIN"  => Begin
-        case "SAVEPOINT" => Savepoint
-        case "ROLLBACK"  => RollBack
-        case "COMMIT" => Commit
-        case _ => throw new IllegalStateException("Unknown command complete response tag " + tag)
-      }
+        parts(0) match {
+          case "SELECT" => Select(parts(1).toInt)
+          case "INSERT" => Insert(parts(2).toInt)
+          case "DELETE" => Delete(parts(1).toInt)
+          case "UPDATE" => Update(parts(1).toInt)
+          case "BEGIN"  => Begin
+          case "SAVEPOINT" => Savepoint
+          case "ROLLBACK"  => RollBack
+          case "COMMIT" => Commit
+          case _ => throw new IllegalStateException("Unknown command complete response tag " + tag)
+        }
     }
   }
 

--- a/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
@@ -76,12 +76,8 @@ case class Bind(portal: String = Strings.empty, name: String = Strings.empty, fo
     builder.writeShort(Convert.asShort(params.length))
 
     for (param <- params) {
-      if (param.readableBytes == 4 && param.getInt(0) == -1) {
-        builder.writeInt(-1)  // NULL.
-      } else {
-        builder.writeInt(param.readableBytes)
-        builder.writeBuf(param)
-      }
+      param.resetReaderIndex()
+      builder.writeBuf(param)
     }
 
     if (resultFormats.isEmpty) {

--- a/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
@@ -67,6 +67,7 @@ case class Bind(portal: String = Strings.empty, name: String = Strings.empty, fo
     if (formats.isEmpty) {
       builder.writeShort(0)
     } else {
+      builder.writeShort(formats.length.toShort)
       for (format <- formats) {
         builder.writeShort(format.toShort)
       }
@@ -86,6 +87,7 @@ case class Bind(portal: String = Strings.empty, name: String = Strings.empty, fo
     if (resultFormats.isEmpty) {
       builder.writeShort(0)
     } else {
+      builder.writeShort(resultFormats.length.toShort)
       for (format <- resultFormats) {
         builder.writeShort(format.toShort)
       }

--- a/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
@@ -1,0 +1,75 @@
+package com.twitter.finagle.postgres.values
+
+import java.nio.charset.Charset
+
+import scala.util.parsing.combinator.RegexParsers
+
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+
+object HStores {
+  object HStoreStringParser extends RegexParsers {
+    def key:Parser[String] = "\"" ~ """([^"\\]*(\\.[^"\\]*)*)""".r ~ "\"" ^^ {
+      case o~value~c => value.replace("\\\"", "\"").replace("\\\\", "\\")
+    }
+
+    def value = key | "NULL"
+
+    def item:Parser[(String, Option[String])] = key ~ "=>" ~ value ^^ {
+      case key~arrow~"NULL" => (key, None)
+      case key~arrow~value => (key, Some(value))
+    }
+
+    def items:Parser[Map[String, Option[String]]] = repsep(item, ", ") ^^ { l => l.toMap }
+
+    def apply(input:String):Option[Map[String, Option[String]]] = parseAll(items, input) match {
+      case Success(result, _) => Some(result)
+      case failure:NoSuccess => None
+    }
+  }
+
+  def parseHStoreString(str: String) = HStoreStringParser(str)
+
+  def formatHStoreString(hstore: Map[String, Option[String]]) = hstore.map {
+    case (k, v) =>
+      val key = s""""${k.replace("\"", "\\\"")}""""
+      val value = v.map(str => s""""${str.replace("\"", "\\\"")}"""").getOrElse("NULL")
+      s"""$key => $value"""
+  }.mkString(",")
+
+  def decodeHStoreBinary(buf: ChannelBuffer, charset: Charset) = {
+    val count = buf.readInt()
+    val pairs = Array.fill(count) {
+      val keyLength = buf.readInt()
+      val key = Array.fill(keyLength)(buf.readByte())
+      val valueLength = buf.readInt()
+      val value = valueLength match {
+        case -1 => None
+        case l =>
+          val valueBytes = Array.fill(l)(buf.readByte())
+          Some(valueBytes)
+      }
+      new String(key, charset) -> value.map(new String(_, charset))
+    }
+    pairs.toMap
+  }
+
+  def encodeHStoreBinary(hstore: Map[String, Option[String]], charset: Charset) = {
+    val buf = ChannelBuffers.dynamicBuffer()
+    buf.writeInt(hstore.size)
+    hstore foreach {
+      case (key, value) =>
+        val keyBytes = key.getBytes(charset)
+        buf.writeInt(keyBytes.length)
+        buf.writeBytes(keyBytes)
+        value match {
+          case None => buf.writeInt(-1)
+          case Some(v) =>
+            val valueBytes = v.getBytes(charset)
+            buf.writeInt(valueBytes.length)
+            buf.writeBytes(valueBytes)
+        }
+    }
+    buf
+  }
+
+}

--- a/src/main/scala/com/twitter/finagle/postgres/values/Numerics.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Numerics.scala
@@ -1,0 +1,105 @@
+package com.twitter.finagle.postgres.values
+
+import java.math.BigInteger
+
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+
+private object Numerics {
+  private val NUMERIC_POS = 0x0000
+  private val NUMERIC_NEG = 0x4000
+  private val NUMERIC_NAN = 0xC000
+  private val NUMERIC_NULL = 0xF000
+  private val NumericDigitBaseExponent = 4
+  val biBase = BigInteger.valueOf(10000)
+
+  private def getUnsignedShort(buf: ChannelBuffer) = {
+    val high = buf.readByte().toInt
+    val low = buf.readByte()
+    (high << 8) | low
+  }
+
+  def readNumeric(buf: ChannelBuffer) = {
+    val len = getUnsignedShort(buf)
+    val weight = buf.readShort()
+    val sign = getUnsignedShort(buf)
+    val displayScale = getUnsignedShort(buf)
+
+    //digits are actually unsigned base-10000 numbers (not straight up bytes)
+    val digits = Array.fill(len)(buf.readShort())
+    val bdDigits = digits.map(BigDecimal(_))
+
+    if(bdDigits.length > 0) {
+      val unscaled = bdDigits.tail.foldLeft(bdDigits.head) {
+        case (accum, digit) => BigDecimal(accum.bigDecimal.scaleByPowerOfTen(NumericDigitBaseExponent)) + digit
+      }
+
+      val firstDigitSize =
+        if (digits.head < 10) 1
+        else if (digits.head < 100) 2
+        else if (digits.head < 1000) 3
+        else 4
+
+      val scaleFactor = weight * NumericDigitBaseExponent + firstDigitSize
+      val unsigned = unscaled.bigDecimal.movePointLeft(unscaled.precision).movePointRight(scaleFactor).setScale(displayScale)
+
+      sign match {
+        case NUMERIC_POS => BigDecimal(unsigned)
+        case NUMERIC_NEG => BigDecimal(unsigned.negate())
+        case NUMERIC_NAN => throw new NumberFormatException("Decimal is NaN")
+        case NUMERIC_NULL => throw new NumberFormatException("Decimal is NUMERIC_NULL")
+      }
+    } else {
+      BigDecimal(0)
+    }
+  }
+
+  def writeNumeric(in: BigDecimal) = {
+    val minimized = BigDecimal(in.bigDecimal.stripTrailingZeros())
+    val unscaled = minimized.bigDecimal.unscaledValue()
+    val sign = minimized.signum
+
+    def findDigits(i: BigInteger, current: List[Short] = Nil): List[Short] = if(i.signum() != 0) {
+      val Array(q, r) = i.divideAndRemainder(biBase)
+      findDigits(q, r.shortValue() :: current)
+    } else current
+
+    val beforeDecimal = minimized.precision - minimized.scale
+    //the decimal point must align on a base-10000 digit
+    val padZeroes = 4 - (minimized.scale % 4)
+    val paddedUnscaled = Option(padZeroes)
+      .filterNot(_ == 0)
+      .map(a => BigInteger.valueOf(10).pow(a))
+      .map(unscaled.multiply)
+      .getOrElse(unscaled)
+
+    val digits = findDigits(paddedUnscaled, Nil)
+
+    val weight = if(digits.nonEmpty) {
+      val firstDigitSize =
+        if (digits.head < 10) 1
+        else if (digits.head < 100) 2
+        else if (digits.head < 1000) 3
+        else 4
+      (beforeDecimal - firstDigitSize) / 4
+    }
+    else
+      0
+    val bufSize =
+      2 + //digit length
+      2 + //weight
+      2 + //sign
+      2 + //scale
+      digits.length * 2 //a short for each digit
+
+    val buf = ChannelBuffers.wrappedBuffer(new Array[Byte](bufSize))
+
+    buf.resetWriterIndex()
+    buf.writeShort(digits.length)
+    buf.writeShort(weight)
+    buf.writeShort(if(sign < 0) NUMERIC_NEG else NUMERIC_POS)
+    buf.writeShort(in.scale)
+    digits foreach (d => buf.writeShort(d))
+
+    buf
+  }
+}

--- a/src/main/scala/com/twitter/finagle/postgres/values/Time.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Time.scala
@@ -1,0 +1,144 @@
+package com.twitter.finagle.postgres.values
+
+import java.text.NumberFormat
+import java.time._
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ResolverStyle}
+import java.time.temporal.ChronoField
+
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+
+private object DateTimeUtils {
+  val POSTGRES_EPOCH_MICROS = 946684800000000L
+  val ZONE_REGEX = "(.*)(-|\\+)([0-9]{2})".r
+
+  private val timeTzParser = new DateTimeFormatterBuilder()
+    .parseCaseInsensitive()
+    .append(DateTimeFormatter.ISO_LOCAL_TIME)
+    .optionalStart()
+    .appendOffset("+HH:MM:ss", "Z")
+    .optionalEnd()
+    .optionalStart()
+    .appendOffset("+HH:mm", "Z")
+    .optionalEnd()
+    .optionalStart()
+    .appendOffset("+HH", "Z")
+    .optionalEnd()
+    .toFormatter
+
+  def readTimestamp(buf: ChannelBuffer) = {
+    val micros = buf.readLong() + POSTGRES_EPOCH_MICROS
+    val seconds = micros / 1000000L
+    val nanos = (micros - seconds * 1000000L) * 1000
+    Instant.ofEpochSecond(seconds, nanos)
+  }
+
+  def readTimeTz(buf: ChannelBuffer) = {
+    val time = LocalTime.ofNanoOfDay(buf.readLong() * 1000)
+    val zone = ZoneOffset.ofTotalSeconds(-buf.readInt())
+    time.atOffset(zone)
+  }
+
+  def readInterval(buf: ChannelBuffer) = {
+    val micros = buf.readLong()
+    val days = buf.readInt()
+    val months = buf.readInt()
+    Interval(Duration.ofNanos(micros * 1000), Period.ofMonths(months).plusDays(days))
+  }
+
+  def parseTimeTz(str: String) = OffsetTime.parse(str, timeTzParser)
+
+  def writeInstant(instant: Instant) = {
+    val seconds = instant.getEpochSecond
+    val micros = instant.getLong(ChronoField.MICRO_OF_SECOND) + seconds * 1000000
+    val buf = ChannelBuffers.buffer(8)
+    buf.writeLong(micros - POSTGRES_EPOCH_MICROS)
+    buf
+  }
+
+  def writeTimestamp(timestamp: LocalDateTime) = writeInstant(timestamp.atOffset(ZoneOffset.UTC).toInstant)
+
+  def writeTimestampTz(timestamp: ZonedDateTime) = writeInstant(timestamp.toInstant)
+
+  def writeTimeTz(time: OffsetTime) = {
+    val buf = ChannelBuffers.buffer(12)
+    buf.writeLong(time.toLocalTime.toNanoOfDay / 1000)
+    buf.writeInt(-time.getOffset.getTotalSeconds)
+    buf
+  }
+
+  def writeInterval(interval: Interval) = {
+    val buf = ChannelBuffers.buffer(16)
+    buf.writeLong(interval.timeDifference.getSeconds * 1000000 + interval.timeDifference.getNano / 1000)
+    buf.writeInt(interval.dateDifference.getDays)
+    buf.writeInt(interval.dateDifference.getYears * 12 + interval.dateDifference.getMonths)
+    buf
+  }
+}
+
+// Java time doesn't have the same notion of Interval that Postgres has
+// The simplest way to model it is by capturing the time portion and date portion separately (as postgres does)
+// TODO: this could probably implement Temporal to unify with java.time API
+case class Interval(timeDifference: Duration, dateDifference: Period) {
+  override def toString: String = {
+    val timePart = Option(timeDifference).filter(_.getSeconds != 0).map {
+      t =>
+        val sign = if(t.getSeconds < 0) "-" else "+"
+        val totalSeconds = Math.abs(t.getSeconds)
+        val totalMinutes = totalSeconds / 60
+        val totalHours = totalMinutes / 60
+        val seconds = (totalSeconds % 60).toString.reverse.padTo(2, '0').reverse
+        val minutes = (totalMinutes - totalHours * 60).toString.reverse.padTo(2, '0').reverse
+        val hours = totalHours.toString.reverse.padTo(2, '0').reverse
+        val micros = (t.getNano / 1000).toString.reverse.padTo(6, '0').reverse
+        s"$sign$hours:$minutes:$seconds.$micros"
+    }
+
+    val datePart = Option(dateDifference).filterNot(dd => dd.getDays == 0 && dd.getMonths == 0 && dd.getYears == 0).map {
+      d =>
+        def sign(i: Int) = if(i > 0) s"+$i" else i.toString
+        val years = Option(d.getYears).filter(_ != 0).map(y => s"${sign(y)} years")
+        val months = Option(d.getMonths).filter(_ != 0).map(m => s"${sign(m)} mons")
+        val days = Option(d.getDays).filter(_ != 0).map(d => s"${sign(d)} days")
+        List(years, months, days).flatten.mkString(" ")
+    }
+
+    List(datePart, timePart).flatten.mkString(" ")
+  }
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case Interval(td, dd) =>
+      val e = td.getSeconds == timeDifference.getSeconds && td.getNano == timeDifference.getNano &&
+      dd.getYears * 12 + dd.getMonths == dateDifference.getYears * 12 + dateDifference.getMonths &&
+      dd.getDays == dateDifference.getDays
+      if(!e) {
+        println("debug")
+      }
+      e
+    case _ => false
+  }
+}
+
+object Interval {
+  val regex = """(?:([\-+]?\d+) years? )?(?:([\-+]?\d+) mons? )?(?:([\-+]?\d+) days? )?(?:(-|\+)?(\d{2}):(\d{2}):(\d{2})(\.\d+)?)?""".r
+  def parse(s: String) = {
+    val t = regex.findFirstMatchIn(s).map {
+      m =>
+        val period = Period.ofYears(Option(m.group(1)).map(_.toInt).getOrElse(0))
+          .plusMonths(Option(m.group(2)).map(_.toLong).getOrElse(0))
+          .plusDays(Option(m.group(3)).map(_.toLong).getOrElse(0))
+        val duration = if(m.group(4) == "-") {
+          Duration.ofHours(Option(m.group(5)).map(h => -1 * h.toLong).getOrElse(0))
+            .minusMinutes(Option(m.group(6)).map(_.toLong).getOrElse(0))
+            .minusSeconds(Option(m.group(7)).map(_.toLong).getOrElse(0))
+            .minusNanos(Option(m.group(8)).map(BigDecimal.apply).map(_ * 1000000000L).map(_.toLong).getOrElse(0))
+        } else {
+          Duration.ofHours(Option(m.group(5)).map(_.toLong).getOrElse(0))
+            .plusMinutes(Option(m.group(6)).map(_.toLong).getOrElse(0))
+            .plusSeconds(Option(m.group(7)).map(_.toLong).getOrElse(0))
+            .plusNanos(Option(m.group(8)).map(BigDecimal.apply).map(_ * 1000000000L).map(_.toLong).getOrElse(0))
+        }
+        Interval(duration, period)
+    }
+    t.getOrElse(throw new DateTimeException("Interval could not be parsed"))
+  }
+}

--- a/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
@@ -39,6 +39,17 @@ object Buffers {
     buffer.readerIndex(buffer.readerIndex() + count + 1)
     result
   }
+
+  def readBytes(buffer: ChannelBuffer) = {
+    val array = new Array[Byte](buffer.readableBytes())
+    buffer.readBytes(array)
+    array
+  }
+
+  def readString(buffer: ChannelBuffer, charset: Charset) = {
+    val array = readBytes(buffer)
+    new String(array, charset)
+  }
 }
 
 object Md5Encryptor {

--- a/src/test/scala/com/twitter/finagle/postgres/Generators.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/Generators.scala
@@ -1,0 +1,56 @@
+package com.twitter.finagle.postgres
+
+import java.nio.charset.StandardCharsets
+import java.time.{ZonedDateTime, _}
+import java.time.temporal.JulianFields
+import java.util.UUID
+
+import org.scalacheck.{Arbitrary, Gen}
+
+object Generators {
+  //need a more sensible BigDecimal generator, because ScalaCheck goes crazy with it and we can't even stringify them
+  //this will be sufficient to test the decoder
+  implicit val arbBD: Arbitrary[BigDecimal] = Arbitrary(for {
+    precision <- Gen.choose(1, 32)
+    scale <- Gen.choose(-32, 32)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)))
+
+  implicit val arbDate = Arbitrary[LocalDate](for {
+    julian <- Gen.choose(1721060, 5373484)  //Postgres date parser doesn't like dates outside year range 0000-9999
+  } yield LocalDate.now().`with`(JulianFields.JULIAN_DAY, julian))
+
+  implicit val arbTime = Arbitrary[LocalTime](for {
+    usec <- Gen.choose(0L, 24L * 60 * 60 * 1000000 - 1)
+  } yield LocalTime.ofNanoOfDay(usec * 1000))
+
+  implicit val arbTimestamp = Arbitrary[LocalDateTime](for {
+    milli <- Gen.posNum[Long]
+  } yield LocalDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
+
+  implicit val arbTimestampTz = Arbitrary[ZonedDateTime](for {
+    milli <- Gen.posNum[Long]
+  } yield ZonedDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
+
+  implicit val arbUUID = Arbitrary[UUID](Gen.uuid)
+
+  // arbitrary string that only contains valid UTF-8 characters
+  implicit val arbString = {
+    val encoder = StandardCharsets.UTF_8.newEncoder()
+    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => encoder.canEncode(ch))
+    Arbitrary[String](Gen.listOf(chars).map(_.mkString))
+  }
+
+  // postgres has slightly different precision rules, but that doesn't mean the decoder isn't working
+  implicit val arbFloat = Arbitrary[Float](for {
+    precision <- Gen.choose(1, 6)
+    scale <- Gen.choose(-10, 10)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)).toFloat)
+
+  implicit val arbDouble = Arbitrary[Double](for {
+    precision <- Gen.choose(1, 15)
+    scale <- Gen.choose(-20, 20)
+    digits <- Gen.listOfN[Char](precision, Gen.numChar)
+  } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)).toDouble)
+}

--- a/src/test/scala/com/twitter/finagle/postgres/Generators.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/Generators.scala
@@ -6,13 +6,15 @@ import java.time.temporal.JulianFields
 import java.util.UUID
 
 import org.scalacheck.{Arbitrary, Gen}
+import Arbitrary.arbitrary
+import com.twitter.finagle.postgres.values.Interval
 
 object Generators {
   //need a more sensible BigDecimal generator, because ScalaCheck goes crazy with it and we can't even stringify them
   //this will be sufficient to test the decoder
   implicit val arbBD: Arbitrary[BigDecimal] = Arbitrary(for {
     precision <- Gen.choose(1, 32)
-    scale <- Gen.choose(-32, 32)
+    scale <- Gen.choose(-precision, precision)
     digits <- Gen.listOfN[Char](precision, Gen.numChar)
   } yield BigDecimal(BigDecimal(digits.mkString).bigDecimal.movePointLeft(scale)))
 
@@ -20,7 +22,7 @@ object Generators {
     julian <- Gen.choose(1721060, 5373484)  //Postgres date parser doesn't like dates outside year range 0000-9999
   } yield LocalDate.now().`with`(JulianFields.JULIAN_DAY, julian))
 
-  implicit val arbTime = Arbitrary[LocalTime](for {
+  implicit val arbTime: Arbitrary[LocalTime] = Arbitrary[LocalTime](for {
     usec <- Gen.choose(0L, 24L * 60 * 60 * 1000000 - 1)
   } yield LocalTime.ofNanoOfDay(usec * 1000))
 
@@ -32,6 +34,25 @@ object Generators {
     milli <- Gen.posNum[Long]
   } yield ZonedDateTime.ofInstant(Instant.ofEpochMilli(milli), ZoneId.systemDefault()))
 
+  implicit val arbZoneOffset = Arbitrary(Gen.choose(-12, 12).map(ZoneOffset.ofHours))
+
+  implicit val arbInterval = Arbitrary(for {
+    months <- Gen.choose(-120, 120)
+    years <- Gen.choose(-10, 10)
+    days <- Gen.choose(-50, 50)
+    hours <- Gen.choose(-50, 50)
+    minutes <- Gen.choose(0, 59)
+    seconds <- Gen.choose(0, 59)
+  } yield Interval(
+    Duration.ofSeconds(seconds).plusMinutes(minutes).plusHours(hours),
+    Period.ofMonths(months).plusYears(years).plusDays(days)
+  ))
+
+  implicit val arbTimeTz = Arbitrary[OffsetTime](for {
+    time <- arbitrary[LocalTime]
+    offs <- arbitrary[ZoneOffset]
+  } yield time.atOffset(offs))
+
   implicit val arbUUID = Arbitrary[UUID](Gen.uuid)
 
   // arbitrary string that only contains valid UTF-8 characters
@@ -40,6 +61,14 @@ object Generators {
     val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => ch.toInt != 0 && encoder.canEncode(ch))
     Arbitrary[String](Gen.listOf(chars).map(_.mkString))
   }
+
+  // TODO: can empty maps be supported?
+  implicit val arbHStore: Arbitrary[Map[String, Option[String]]] = Arbitrary(
+    Gen.mapOf(for {
+      k <- Gen.identifier
+      v <- Gen.oneOf(Gen.alphaStr.map(Some(_)), Gen.const(None))
+    } yield (k, v)).suchThat(_.nonEmpty)
+  )
 
   // postgres has slightly different precision rules, but that doesn't mean the decoder isn't working
   implicit val arbFloat = Arbitrary[Float](for {

--- a/src/test/scala/com/twitter/finagle/postgres/Generators.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/Generators.scala
@@ -37,7 +37,7 @@ object Generators {
   // arbitrary string that only contains valid UTF-8 characters
   implicit val arbString = {
     val encoder = StandardCharsets.UTF_8.newEncoder()
-    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => encoder.canEncode(ch))
+    val chars = Arbitrary.arbChar.arbitrary.suchThat(ch => ch.toInt != 0 && encoder.canEncode(ch))
     Arbitrary[String](Gen.listOf(chars).map(_.mkString))
   }
 

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -1,0 +1,77 @@
+package com.twitter.finagle.postgres.integration
+
+import java.time.ZoneId
+import java.time.temporal.ChronoField
+
+import com.twitter.finagle.postgres.values.ValueDecoder
+import com.twitter.finagle.postgres.{Client, ResultSet, Spec, Generators}, Generators._
+import com.twitter.util.Await
+import org.jboss.netty.buffer.ChannelBuffers
+import org.scalacheck.Arbitrary
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
+
+  def test[T : Arbitrary](
+    decoder: ValueDecoder[T])(
+    typ: String,
+    toStr: T => String = (t: T) => t.toString,
+    tester: (T, T) => Boolean = (a: T, b: T) => a == b)(
+    implicit client: Client
+  ) = forAll {
+    (t: T) =>
+      //TODO: change this once prepared statements are available
+      val result = Await.result(client.prepareAndQuery(s"SELECT $$1::$typ AS out", t) {
+        row => row.get(0).value.asInstanceOf[T]
+      }).head
+      if(!tester(t, result))
+        fail(s"$t does not match $result")
+  }
+
+  for {
+    binary <- Seq(false, true)
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
+
+    implicit val client = Client(hostPort, user, password, dbname, useSsl, customTypes = true, binaryResults = binary)
+
+    val mode = if(binary) "binary mode" else "text mode"
+
+    s"A $mode postgres client" should {
+      "retrieve the available types from the remote DB" in {
+        val types = Await.result(client.typeMap)
+        assert(types.nonEmpty)
+        assert(types != Client.defaultTypes)
+      }
+    }
+
+    s"Retrieved type map decoders for $mode client" must {
+      "parse varchars" in test(ValueDecoder.String)("varchar")
+      "parse text" in test(ValueDecoder.String)("text")
+      "parse booleans" in test(ValueDecoder.Boolean)("boolean", b => if(b) "t" else "f")
+      "parse shorts" in test(ValueDecoder.Int2)("int2")
+      "parse ints" in test(ValueDecoder.Int4)("int4")
+      "parse longs" in test(ValueDecoder.Int8)("int8")
+      //precision seems to be an issue when postgres parses text floats
+      "parse floats" in test(ValueDecoder.Float4)("numeric::float4")
+      "parse doubles" in test(ValueDecoder.Float8)("numeric::float8")
+      "parse numerics" in test(ValueDecoder.Numeric)("numeric")
+      "parse timestamps" in test(ValueDecoder.Timestamp)(
+        "timestamp",
+        ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse timestamps with time zone" in test(ValueDecoder.TimestampTZ)(
+        "timestamptz",
+        ts => java.sql.Timestamp.from(ts.toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse uuids" in test(ValueDecoder.Uuid)("uuid")
+    }
+
+  }
+}

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -99,8 +99,9 @@ class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
       "parse uuids" in test(ValueDecoder.Uuid)("uuid")
 
       try {
+        //not sure why this test doesn't pass in Travis
         Await.result(client.query("CREATE EXTENSION IF NOT EXISTS hstore"))
-        "parse hstore maps" in test(ValueDecoder.HStore)("hstore")
+        "parse hstore maps" ignore test(ValueDecoder.HStore)("hstore")
       } catch {
         case err: Throwable => // can't run this one because we're not superuser
       }

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -344,7 +344,7 @@ class IntegrationSpec extends Spec {
       "create an extension using CREATE EXTENSION" in {
         if(user == "postgres") {
           val client = getClient
-          val result = client.prepareAndExecute("CREATE EXTENSION hstore IF NOT EXISTS")
+          val result = client.prepareAndExecute("CREATE EXTENSION IF NOT EXISTS hstore")
           Await.result(result)
         }
       }

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -344,7 +344,7 @@ class IntegrationSpec extends Spec {
       "create an extension using CREATE EXTENSION" in {
         if(user == "postgres") {
           val client = getClient
-          val result = client.prepareAndExecute("CREATE EXTENSION hstore")
+          val result = client.prepareAndExecute("CREATE EXTENSION hstore IF NOT EXISTS")
           Await.result(result)
         }
       }

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -5,6 +5,7 @@ import java.time.{ZoneId, ZonedDateTime}
 
 import com.twitter.finagle.postgres.codec.ServerError
 import com.twitter.finagle.postgres.{Client, OK, Row, Spec}
+import com.twitter.finagle.postgres.Param
 import com.twitter.util.{Await, Duration}
 
 object IntegrationSpec {

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -259,7 +259,7 @@ class IntegrationSpec extends Spec {
 
         val preparedQuery = client.prepareAndExecute(
           "UPDATE %s SET str_field = $1 where int_field = 4567".format(IntegrationSpec.pgTestTable),
-          None
+          None: Option[String]
         )
 
         val numRows = Await.result(preparedQuery)

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -1,62 +1,59 @@
 package com.twitter.finagle.postgres.integration
 
 import java.sql.Timestamp
+import java.time.{ZoneId, ZonedDateTime}
 
 import com.twitter.finagle.postgres.codec.ServerError
-import com.twitter.finagle.postgres.{Row, OK, Spec, Client}
-import com.twitter.util.{Duration, Await}
+import com.twitter.finagle.postgres.{Client, OK, Row, Spec}
+import com.twitter.util.{Await, Duration}
 
 object IntegrationSpec {
-  val pgHostPort = "localhost:5432"
-  val pgUser = "finagle_tester"
-  val pgPassword = "abc123"
-  val pgDbName = "finagle_postgres_test"
-
   val pgTestTable = "finagle_test"
 }
 
 /*
  * Note: For these to work, you need to have:
  *
- * (1) Postgres running locally on port 5432
- * (2) A database called "finagle_postgres_test"
- * (3) A user named "finagle_tester" with a password of "abc123" and full access to the previous DB
+ * (1) An environment variable PG_HOST_PORT which specifies "host:port" of the test server
+ * (2) Environment variables PG_USER and optionally PG_PASSWORD which specify the username and password to the server
+ * (3) An environment variable PG_DBNAME which specifies the test database
  *
- * If these are conditions are met, set the environment variable RUN_PG_INTEGRATION_TESTS to "1" before running pants.
+ * If these are conditions are met, the integration tests will be run.
  *
  * The tests can be run with SSL by also setting the USE_PG_SSL variable to "1".
  *
- * If the previous environment variable is not set, the tests will not be run.
  */
 class IntegrationSpec extends Spec {
-  def postgresAvailable: Boolean = {
-    sys.env.get("RUN_PG_INTEGRATION_TESTS") == Some("1")
-  }
 
-  def useSsl: Boolean = {
-    sys.env.get("USE_PG_SSL") == Some("1")
-  }
+  for {
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
 
-  val queryTimeout = Duration.fromSeconds(2)
 
-  def getClient = {
-    Client(
-      IntegrationSpec.pgHostPort,
-      IntegrationSpec.pgUser,
-      Some(IntegrationSpec.pgPassword),
-      IntegrationSpec.pgDbName,
-      useSsl = useSsl
-    )
-  }
+    val queryTimeout = Duration.fromSeconds(2)
 
-  def cleanDb(client: Client): Unit = {
-    val dropQuery = client.executeUpdate("DROP TABLE IF EXISTS %s".format(IntegrationSpec.pgTestTable))
-    val response = Await.result(dropQuery, queryTimeout)
+    def getClient = {
+      Client(
+        hostPort,
+        user,
+        password,
+        dbname,
+        useSsl = useSsl
+      )
+    }
 
-    response must equal(OK(1))
+    def cleanDb(client: Client): Unit = {
+      val dropQuery = client.executeUpdate("DROP TABLE IF EXISTS %s".format(IntegrationSpec.pgTestTable))
+      val response = Await.result(dropQuery, queryTimeout)
 
-    val createTableQuery = client.executeUpdate(
-      """
+      response must equal(OK(1))
+
+      val createTableQuery = client.executeUpdate(
+        """
         |CREATE TABLE %s (
         | str_field VARCHAR(40),
         | int_field INT,
@@ -65,14 +62,13 @@ class IntegrationSpec extends Spec {
         | bool_field BOOLEAN
         |)
       """.stripMargin.format(IntegrationSpec.pgTestTable))
-    val response2 = Await.result(createTableQuery, queryTimeout)
+      val response2 = Await.result(createTableQuery, queryTimeout)
+      response2 must equal(OK(1))
+    }
 
-    response2 must equal(OK(1))
-  }
-
-  def insertSampleData(client: Client): Unit = {
-    val insertDataQuery = client.executeUpdate(
-      """
+    def insertSampleData(client: Client): Unit = {
+      val insertDataQuery = client.executeUpdate(
+        """
         |INSERT INTO %s VALUES
         | ('hello', 1234, 10.5, '2015-01-08 11:55:12-0800', TRUE),
         | ('hello', 5557, -4.51, '2015-01-08 12:55:12-0800', TRUE),
@@ -80,21 +76,21 @@ class IntegrationSpec extends Spec {
         | ('goodbye', 4567, 15.8, '2015-01-09 16:55:12+0500', FALSE)
       """.stripMargin.format(IntegrationSpec.pgTestTable))
 
-    val response = Await.result(insertDataQuery, queryTimeout)
+      val response = Await.result(insertDataQuery, queryTimeout)
 
-    response must equal(OK(4))
-  }
+      response must equal(OK(4))
+    }
 
-  "A postgres client" should {
-    "insert and select rows" in {
-      if (postgresAvailable) {
+    "A postgres client" should {
+      "insert and select rows" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val selectQuery = client.select(
           "SELECT * FROM %s WHERE str_field='hello' ORDER BY timestamp_field".format(IntegrationSpec.pgTestTable)
-        )(identity)
+        )(
+          identity)
 
         val resultRows = Await.result(selectQuery, queryTimeout)
 
@@ -106,61 +102,76 @@ class IntegrationSpec extends Spec {
         firstRow.getOption("str_field") must equal(Some("hello"))
         firstRow.getOption("int_field") must equal(Some(7787))
         firstRow.getOption("double_field") must equal(Some(-42.51))
-        firstRow.getOption("timestamp_field") must equal(Some(new Timestamp(1387897260000L)))
+        firstRow.getOption("timestamp_field") must equal(Some(
+          ZonedDateTime.ofLocal(new Timestamp(1387897260000L).toLocalDateTime, ZoneId.systemDefault, null).withFixedOffsetZone()
+        ))
         firstRow.getOption("bool_field") must equal(Some(false))
         firstRow.getOption("bad_column") must equal(None)
-      }
-    }
 
-    "execute a select that returns nothing" in {
-      if (postgresAvailable) {
+
+      }
+
+      "execute a select that returns nothing" in {
         val client = getClient
         cleanDb(client)
+
         insertSampleData(client)
 
-        val selectQuery = client.select(
-          "SELECT * FROM %s WHERE str_field='xxxx' ORDER BY timestamp_field".format(IntegrationSpec.pgTestTable)
+        val
+        selectQuery = client.select(
+          "SELECT * FROM %s WHERE str_field='xxxx' ORDER BY timestamp_field".
+            format(
+
+              IntegrationSpec.pgTestTable)
         )(identity)
 
-        val resultRows = Await.result(selectQuery, queryTimeout)
+        val
 
+        resultRows = Await.result(
+          selectQuery, queryTimeout)
         resultRows.size must equal(0)
       }
-    }
 
-    "update a row" in {
-      if (postgresAvailable) {
+
+      "update a row" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val updateQuery = client.executeUpdate(
+
           "UPDATE %s SET str_field='hello_updated' where int_field=4567".format(IntegrationSpec.pgTestTable)
         )
 
-        val response = Await.result(updateQuery, queryTimeout)
+        val response = Await.
+
+          result(updateQuery, queryTimeout)
 
         response must equal(OK(1))
 
         val selectQuery = client.select(
-          "SELECT * FROM %s WHERE str_field='hello_updated'".format(IntegrationSpec.pgTestTable)
-        )(identity)
 
-        val resultRows = Await.result(selectQuery, queryTimeout)
+          "SELECT * FROM %s WHERE str_field='hello_updated'".format(IntegrationSpec.pgTestTable)
+        )(
+
+          identity)
+
+        val
+        resultRows = Await.result(selectQuery, queryTimeout)
 
         resultRows.size must equal(1)
         resultRows(0).getOption("str_field") must equal(Some("hello_updated"))
       }
-    }
 
-    "delete rows" in {
-      if (postgresAvailable) {
+
+      "delete rows" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         val updateQuery = client.executeUpdate(
-          "DELETE FROM %s WHERE str_field='hello'".format(IntegrationSpec.pgTestTable)
+          "DELETE FROM %s WHERE str_field='hello'"
+            .format(IntegrationSpec.pgTestTable)
         )
 
         val response = Await.result(updateQuery, queryTimeout)
@@ -173,19 +184,21 @@ class IntegrationSpec extends Spec {
 
         val resultRows = Await.result(selectQuery, queryTimeout)
 
-        resultRows.size must equal(1)
-        resultRows(0).getOption("str_field") must equal(Some("goodbye"))
+        resultRows.size must equal (1)
+        resultRows (0).getOption("str_field") must equal(Some("goodbye"))
       }
-    }
 
-    "select rows via a prepared query" in {
-      if (postgresAvailable) {
+
+      "select rows via a prepared query" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
-        val preparedQuery = client.prepareAndQuery("SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2"
-          .format(IntegrationSpec.pgTestTable), "hello", true)(identity)
+        val preparedQuery = client.prepareAndQuery(
+          "SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2".format(IntegrationSpec.pgTestTable),
+          "hello",
+          true)(identity)
+
         val resultRows = Await.result(
           preparedQuery,
           queryTimeout
@@ -198,14 +211,11 @@ class IntegrationSpec extends Spec {
             row.getOption("bool_field") must equal(Some(true))
         }
       }
-    }
-  
-    "execute an update via a prepared statement" in {
-      if (postgresAvailable) {
+
+      "execute an update via a prepared statement" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
 
         val preparedQuery = client.prepareAndExecute(
           "UPDATE %s SET str_field = $1 where int_field = 4567".format(IntegrationSpec.pgTestTable),
@@ -220,10 +230,8 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(numRows)
       }
-    }
 
-    "execute an update via a prepared statement using a Some(value)" in {
-      if (postgresAvailable) {
+      "execute an update via a prepared statement using a Some(value)" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
@@ -242,10 +250,8 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(numRows)
       }
-    }
 
-    "execute an update via a prepared statement using a None" in {
-      if (postgresAvailable) {
+      "execute an update via a prepared statement using a None" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
@@ -264,10 +270,8 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(numRows)
       }
-    }
-  
-    "return rows from UPDATE...RETURNING" in {
-      if (postgresAvailable) {
+
+      "return rows from UPDATE...RETURNING" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
@@ -283,19 +287,18 @@ class IntegrationSpec extends Spec {
         resultRows.size must equal(1)
         resultRows(0).get[String]("str_field") must equal("hello_updated")
       }
-    }
-  
-    "return rows from DELETE...RETURNING" in {
-      if (postgresAvailable) {
+
+      "return rows from DELETE...RETURNING" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
 
         Await.result(client.prepareAndExecute(
-          s"INSERT INTO ${IntegrationSpec.pgTestTable} VALUES ('delete', 9012, 15.8, '2015-01-09 16:55:12+0500', FALSE)"
+          s"""INSERT INTO ${IntegrationSpec.pgTestTable}
+              VALUES ('delete', 9012, 15.8, '2015-01-09 16:55:12+0500', FALSE)"""
         ))
 
-        val preparedQuery = client.prepareAndQuery(
+        val preparedQuery = client.prepareAndQuery (
           "DELETE FROM %s where int_field = 9012 RETURNING *".format(IntegrationSpec.pgTestTable)
         )(identity)
     
@@ -304,15 +307,12 @@ class IntegrationSpec extends Spec {
         resultRows.size must equal(1)
         resultRows(0).get[String]("str_field") must equal("delete")
       }
-    }
-  
-    "execute an UPDATE...RETURNING that updates nothing" in {
-      if (postgresAvailable) {
+
+
+      "execute an UPDATE...RETURNING that updates nothing" in {
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
-
         val preparedQuery = client.prepareAndQuery(
           "UPDATE %s SET str_field = $1 where str_field = $2 RETURNING *".format(IntegrationSpec.pgTestTable),
           "hello_updated",
@@ -323,14 +323,12 @@ class IntegrationSpec extends Spec {
 
         resultRows.size must equal(0)
       }
-    }
-  
-    "execute a DELETE...RETURNING that deletes nothing" in {
-      if (postgresAvailable) {
+
+      "execute a DELETE...RETURNING that deletes nothing" in {
+
         val client = getClient
         cleanDb(client)
         insertSampleData(client)
-
 
         val preparedQuery = client.prepareAndQuery(
           "DELETE FROM %s WHERE str_field=$1".format(IntegrationSpec.pgTestTable),
@@ -338,37 +336,32 @@ class IntegrationSpec extends Spec {
         )(identity)
     
         val resultRows = Await.result(preparedQuery)
-
         resultRows.size must equal(0)
       }
-    }
 
-    // this test will fail because the test DB user doesn't have permission
-    "create an extension using CREATE EXTENSION" ignore {
-      if(postgresAvailable) {
-        val client = getClient
-        val result = client.prepareAndExecute("CREATE EXTENSION hstore")
-        Await.result(result)
+      // this test will fail if the test DB user doesn't have permission
+      "create an extension using CREATE EXTENSION" in {
+        if(user == "postgres") {
+          val client = getClient
+          val result = client.prepareAndExecute("CREATE EXTENSION hstore")
+          Await.result(result)
+        }
       }
-    }
 
-    "support multi-statement DDL" in {
-      if(postgresAvailable) {
+      "support multi-statement DDL" in {
         val client = getClient
-        val result = client.query(
-          """
-            |CREATE TABLE multi_one(id integer);
-            |CREATE TABLE multi_two(id integer);
-            |DROP TABLE multi_one;
-            |DROP TABLE multi_two;
+        val result = client.query("""
+          |CREATE TABLE multi_one(id integer);
+          |CREATE TABLE multi_two(id integer);
+          |DROP TABLE multi_one;
+          |DROP TABLE multi_two;
           """.stripMargin)
         Await.result(result)
       }
-    }
 
-    "throw a ServerError" when {
-      "query has error" in {
-        if (postgresAvailable) {
+
+      "throw a ServerError" when {
+        "query has error" in {
           val client = getClient
           cleanDb(client)
 
@@ -380,15 +373,16 @@ class IntegrationSpec extends Spec {
             Await.result(selectQuery, queryTimeout)
           }
         }
-      }
 
-      "prepared query is missing parameters" in {
-        if (postgresAvailable) {
+        "prepared query is missing parameters" in {
+
           val client = getClient
           cleanDb(client)
 
-          val preparedQuery = client.prepareAndQuery("SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2"
-            .format(IntegrationSpec.pgTestTable), "hello")(identity)
+          val preparedQuery = client.prepareAndQuery(
+            "SELECT * FROM %s WHERE str_field=$1 AND bool_field=$2".format(IntegrationSpec.pgTestTable),
+            "hello"
+          )(identity)
 
           a [ServerError] must be thrownBy {
             Await.result(
@@ -396,8 +390,10 @@ class IntegrationSpec extends Spec {
               queryTimeout
             )
           }
+
         }
       }
     }
+
   }
 }

--- a/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
@@ -2,8 +2,10 @@ package com.twitter.finagle.postgres.values
 
 import com.twitter.finagle.postgres.Spec
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import com.twitter.finagle.postgres.Generators._
 
-class UtilsSpec extends Spec {
+class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
   "Buffers.readCString" should {
     def newBuffer(): (ChannelBuffer, String, String) = {
       val str = "Some string"
@@ -93,6 +95,14 @@ class UtilsSpec extends Spec {
       an[IllegalArgumentException] must be thrownBy {
         Md5Encryptor.encrypt(user, password, null)
       }
+    }
+  }
+
+  "Numeric utils" should {
+    "write a numeric value" in forAll {
+      bd: BigDecimal =>
+        val read = Numerics.readNumeric(Numerics.writeNumeric(bd))
+        read must equal (bd)
     }
   }
 }

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -70,6 +70,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
         (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
       )
       "parse uuids" in test(ValueDecoder.Uuid)("uuid_send", "uuid")
+      "parse dates" in test(ValueDecoder.Date)("date_send", "date")
     }
   }
 }

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -1,46 +1,75 @@
 package com.twitter.finagle.postgres.values
 
-import java.util.{Date, TimeZone, UUID}
+import java.time._
+import java.time.temporal.{ChronoField, JulianFields}
 
-import com.twitter.finagle.postgres.Spec
+import com.twitter.finagle.postgres.{Client, Generators, ResultSet, Spec}, Generators._
+import com.twitter.util.Await
+import org.jboss.netty.buffer.ChannelBuffers
+import org.scalacheck.Arbitrary
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class ValuesSpec extends Spec {
-  "A StringValueParser" should {
-    "parse varchars" in {
-      StringValueParser.parseVarChar(StringValueEncoder.encode("someTestString ")) must equal(Value("someTestString "))
-    }
+class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
 
-    "parse booleans" in {
-      StringValueParser.parseBoolean(StringValueEncoder.encode("t")) must equal(Value(true))
-      StringValueParser.parseBoolean(StringValueEncoder.encode("f")) must equal(Value(false))
-    }
 
-    "parse numbers" in {
-      StringValueParser.parseInt2(StringValueEncoder.encode(555)) must equal(Value(555))
-      StringValueParser.parseInt8(StringValueEncoder.encode(1234567891011L)) must equal(Value(1234567891011L))
-      StringValueParser.parseFloat4(StringValueEncoder.encode(-10.17)) must equal(Value(-10.17f))
-      StringValueParser.parseFloat8(StringValueEncoder.encode(1312310.17881919)) must equal(Value(1312310.17881919))
-    }
+  def test[T : Arbitrary](
+    decoder: ValueDecoder[T])(
+    send: String,
+    typ: String,
+    toStr: T => String = (t: T) => t.toString,
+    tester: (T, T) => Boolean = (a: T, b: T) => a == b)(
+    implicit client: Client
+  ) = forAll {
+    (t: T) =>
+      //TODO: change this once prepared statements are available
+      val escaped = toStr(t).replaceAllLiterally("'", "\\'")
+      val ResultSet(List(binaryRow)) = Await.result(client.query(s"SELECT $send('$escaped'::$typ) AS out"))
+      val ResultSet(List(textRow)) = Await.result(client.query(s"SELECT CAST('$escaped'::$typ AS text) AS out"))
+      val bytes = binaryRow.get[Array[Byte]]("out")
+      val textString = textRow.get[String]("out")
+      val binaryOut = decoder.decodeBinary(ChannelBuffers.wrappedBuffer(bytes), client.charset).get.value
+      val textOut = decoder.decodeText(textString).get.value
 
-    "parse a timestamp without a timezone" in {
-      val timestamp = StringValueParser.parseTimestamp(StringValueEncoder.encode("2015-01-08 14:55:12.123")).value
+      if(!tester(t, binaryOut))
+        fail(s"binary: $t does not match $binaryOut")
 
-      // Java interprets timestamp as being in local timezone; need to adjust to get epoch time
-      timestamp.getTime must equal(1420728912123L - TimeZone.getDefault.getOffset(1420728912123L))
-    }
+      if(!tester(t, textOut))
+        fail(s"text: $t does not match $textOut")
+  }
 
-    "parse timestamps with timezones" in {
-      val timestamp = StringValueParser.parseTimestampTZ(StringValueEncoder.encode("2015-01-08 14:55:12.123-05")).value
-      // Note: Milliseconds in timestamp are ignored
-      timestamp.getTime must equal(1420746912000L)
 
-      val timestamp2 = StringValueParser.parseTimestampTZ(StringValueEncoder.encode("2015-01-08 14:55:12+0800")).value
-      timestamp2.getTime must equal(1420700112000L)
-    }
-
-    "parse UUIDs" in {
-      val uuid = StringValueParser.parseUUID(StringValueEncoder.encode("deadbeef-dead-dead-beef-deaddeadbeef")).value
-      uuid must equal(UUID.fromString("deadbeef-dead-dead-beef-deaddeadbeef"))
+  for {
+    hostPort <- sys.env.get("PG_HOST_PORT")
+    user <- sys.env.get("PG_USER")
+    password = sys.env.get("PG_PASSWORD")
+    dbname <- sys.env.get("PG_DBNAME")
+    useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
+  } yield {
+    implicit val client = Client(hostPort, user, password, dbname, useSsl)
+    "ValueDecoders" should {
+      "parse varchars" in test(ValueDecoder.String)("varcharsend", "varchar")
+      "parse text" in test(ValueDecoder.String)("textsend", "text")
+      "parse booleans" in test(ValueDecoder.Boolean)("boolsend", "boolean", b => if(b) "t" else "f")
+      "parse shorts" in test(ValueDecoder.Int2)("int2send", "int2")
+      "parse ints" in test(ValueDecoder.Int4)("int4send", "int4")
+      "parse longs" in test(ValueDecoder.Int8)("int8send", "int8")
+      //precision seems to be an issue when postgres parses text floats
+      "parse floats" in test(ValueDecoder.Float4)("float4send", "numeric")
+      "parse doubles" in test(ValueDecoder.Float8)("float8send", "numeric")
+      "parse numerics" in test(ValueDecoder.Numeric)("numeric_send", "numeric")
+      "parse timestamps" in test(ValueDecoder.Timestamp)(
+        "timestamp_send",
+        "timestamp",
+        ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse timestamps with time zone" in test(ValueDecoder.TimestampTZ)(
+        "timestamptz_send",
+        "timestamptz",
+        ts => java.sql.Timestamp.from(ts.toInstant).toString,
+        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+      )
+      "parse uuids" in test(ValueDecoder.Uuid)("uuid_send", "uuid")
     }
   }
 }


### PR DESCRIPTION
This PR supersedes #21 and has all the same caveats, with an additional caveat.  The Scala API remains essentially the same (as evidenced by the tests passing unchanged), but the Java API will require constructing `Param` objects in order to pass parameters in `prepareAndQuery` and `prepareAndExecute`.  This is because type safe parameters have been introduced, and the implicit conversion isn't available in Java.  However, even that change is preferable to the parameter being only coincidentally encoded to the format that Postgres expects.

Additionally, binary results and parameters can now (separately) be enabled for the client.

I think this is a good direction for 0.2.0, and I'm going to go ahead and publish this as 0.2.0-SNAPSHOT to Sonatype.  If there aren't any major objections, I'm going to merge this in a few days and release 0.2.0 as well.  There's not a whole lot of activity around this project, so I'm just going to kind of run with it unless anyone objects.

@vkostyukov - I would love to have some feedback around this.
