### PR TITLE
Add retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ val client = Client(
   database = "dbname",
   useSsl = false,             // Optional - defaults to `false`
   hostConnectionLimit = 1,    // Optional - defaults to `1`
-  numRetries = 4,             // Optional - defaults to `4`
+  retryPolicy = RetryPolicy.tries(4) // Optional - defaults to exponential backoff starting at 50ms
   customTypes = false,        // Optional - defaults to `false
   customReceiveFunctions = {  // Optional - defaults to no-op partial function
     case "mytyperecv" => ValueDecoder.instance(str => ???, (buf, charset) => ???)

--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -440,8 +440,6 @@ object Client {
     binaryResults: Boolean = false,
     binaryParams: Boolean = false
   ): Client = {
-    val id = Random.alphanumeric.take(28).mkString
-
     // Classify responses appropriately - a ServerError with SQLState or ClientError does not mean that the client is
     // down.
     val classifier: ResponseClassifier = {


### PR DESCRIPTION
The currently used `.retries(n)` does not do anything for a
`buildFactory` application. Use a sensible retry policy instead.

This should be made configurable for 0.2.1 release.
