### PR TITLE
Upgraded finagle to the latest 6.39.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val buildSettings = Seq(
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-core" % "6.36.0",
+    "com.twitter" %% "finagle-core" % "6.39.0",
     "junit" % "junit" % "4.7" % "test,it",
     "org.scalatest" %% "scalatest" % "2.2.5" % "test,it",
     "org.mockito" % "mockito-all" % "1.9.5" % "test,it",


### PR DESCRIPTION
Good Evening,
This PR is simply upgrading the finagle dependency to point to the latest [finagle release](https://github.com/twitter/finagle/releases/tag/finagle-6.39.0)
