### PR TITLE
Added citext type

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/Client.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Client.scala
@@ -422,9 +422,10 @@ object Client {
     Type.NUMERIC -> TypeSpecifier("numeric_recv", "numeric"),
     Type.RECORD -> TypeSpecifier("record_recv", "record"),
     Type.VOID -> TypeSpecifier("void_recv", "void"),
-    Type.UUID -> TypeSpecifier("uuid_recv", "uuid")
+    Type.UUID -> TypeSpecifier("uuid_recv", "uuid"),
+    Type.CITEXT -> TypeSpecifier("textrecv", "citext")
   )
-
+    
   def apply(
     host: String,
     username: String,

--- a/src/main/scala/com/twitter/finagle/postgres/values/Values.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Values.scala
@@ -64,6 +64,7 @@ object Type {
   val RECORD = 2249
   val VOID = 2278
   val UUID = 2950
+  val CITEXT = 16388
 }
 
 trait ValueDecoder[+T] {

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -1,15 +1,13 @@
 package com.twitter.finagle.postgres.integration
 
-import java.time.ZoneId
 import java.time.temporal.ChronoField
 
+import com.twitter.finagle.postgres.Generators._
 import com.twitter.finagle.postgres.values.{ValueDecoder, ValueEncoder}
-import com.twitter.finagle.postgres.{Client, Generators, ResultSet, Spec}
+import com.twitter.finagle.postgres.{Client, Spec}
 import com.twitter.util.Await
-import org.jboss.netty.buffer.ChannelBuffers
 import org.scalacheck.Arbitrary
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import Generators._
 
 class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
 
@@ -104,6 +102,13 @@ class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
         "parse hstore maps" ignore test(ValueDecoder.HStore)("hstore")
       } catch {
         case err: Throwable => // can't run this one because we're not superuser
+      }
+
+      try {
+          Await.result(client.query("CREATE EXTENSION IF NOT EXISTS citext"))
+          "parse citext" in test(ValueDecoder.String)("citext")
+      } catch {
+          case err: Throwable =>
       }
     }
 

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -1,9 +1,10 @@
 package com.twitter.finagle.postgres.values
 
 import java.time._
-import java.time.temporal.{ChronoField, JulianFields}
+import java.time.temporal.ChronoField
 
-import com.twitter.finagle.postgres.{Client, Generators, ResultSet, Spec}, Generators._
+import com.twitter.finagle.postgres.Generators._
+import com.twitter.finagle.postgres.{Client, ResultSet, Spec}
 import com.twitter.util.Await
 import org.jboss.netty.buffer.ChannelBuffers
 import org.scalacheck.Arbitrary
@@ -49,6 +50,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
     "ValueDecoders" should {
       "parse varchars" in test(ValueDecoder.String)("varcharsend", "varchar")
       "parse text" in test(ValueDecoder.String)("textsend", "text")
+      "parse citext" in test(ValueDecoder.String)("textsend", "citext")
       "parse booleans" in test(ValueDecoder.Boolean)("boolsend", "boolean", b => if(b) "t" else "f")
       "parse shorts" in test(ValueDecoder.Int2)("int2send", "int2")
       "parse ints" in test(ValueDecoder.Int4)("int4send", "int4")

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -50,7 +50,6 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
     "ValueDecoders" should {
       "parse varchars" in test(ValueDecoder.String)("varcharsend", "varchar")
       "parse text" in test(ValueDecoder.String)("textsend", "text")
-      "parse citext" in test(ValueDecoder.String)("textsend", "citext")
       "parse booleans" in test(ValueDecoder.Boolean)("boolsend", "boolean", b => if(b) "t" else "f")
       "parse shorts" in test(ValueDecoder.Int2)("int2send", "int2")
       "parse ints" in test(ValueDecoder.Int4)("int4send", "int4")


### PR DESCRIPTION
Problem

queries that contain `citext` datatypes are not decoded by finagle-postgres

Example:

``` scala
case class CiName(name: String)
val n = client.select("""select 'thing'::citext as name""") { row => CiName(row.get[String]("name")) }

val f = Await.result(n)

/**
java.lang.ClassCastException: [B cannot be cast to java.lang.String
  at $anonfun$1.apply(<console>:24)
  at $anonfun$1.apply(<console>:24)
  at scala.collection.immutable.List.map(List.scala:273)
  at com.twitter.finagle.postgres.Client$$anonfun$select$1$$anonfun$apply$27.apply(Client.scala:155)
  at com.twitter.finagle.postgres.Client$$anonfun$select$1$$anonfun$apply$27.apply(Client.scala:155)
  at com.twitter.util.Future$$anonfun$map$1$$anonfun$apply$3.apply(Future.scala:1148)
  at com.twitter.util.Try$.apply(Try.scala:13)
...
... many more ..
...
*/
```

Solution

Added new Type and type -> decoder to the default map

Result

`citext` datatypes are now decoded as expected
