### PR TITLE
Fix error syncing

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
@@ -52,6 +52,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired) extends Stat
     case (Describe(_, _), Connected) => (None, AwaitParamsDescription)
     case (Execute(_, _), Connected) => (None, ExecutePreparedStatement)
     case (Sync, Connected) => (None, Syncing)
+    case (Sync, state: ExtendedQueryState) => (None, Syncing)
     case (ErrorResponse(details), Connected) => (Some(Error(details)), Connected)
   }
 

--- a/src/main/scala/com/twitter/finagle/postgres/connection/States.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/States.scala
@@ -7,7 +7,11 @@ import scala.collection.mutable.ListBuffer
 /*
  * Connection states.
  */
-trait State
+sealed trait State
+
+
+
+case object SimpleQuery extends State
 
 case object RequestingSsl extends State
 
@@ -23,22 +27,23 @@ case class AggregatingAuthData(statuses: Map[String, String], processId: Int, se
 
 case object Connected extends State
 
-case object Parsing extends State
-
-case object Binding extends State
-
-case object SimpleQuery extends State
-
-case object ExecutePreparedStatement extends State
-
 case object Syncing extends State
 
-case object AwaitParamsDescription extends State
+// All of the extended query states - Sync can be issued while in these states
+sealed trait ExtendedQueryState extends State
 
-case class AggregateRows(fields: IndexedSeq[Field], buff: ListBuffer[DataRow] = ListBuffer()) extends State
+case object Parsing extends ExtendedQueryState
 
-case class AggregateRowsWithoutFields(buff: ListBuffer[DataRow] = ListBuffer()) extends State
+case object Binding extends ExtendedQueryState
 
-case class AwaitRowDescription(types: IndexedSeq[Int]) extends State
+case object ExecutePreparedStatement extends ExtendedQueryState
 
-case class EmitOnReadyForQuery[R <: PgResponse](emit: R) extends State
+case object AwaitParamsDescription extends ExtendedQueryState
+
+case class AggregateRows(fields: IndexedSeq[Field], buff: ListBuffer[DataRow] = ListBuffer()) extends ExtendedQueryState
+
+case class AggregateRowsWithoutFields(buff: ListBuffer[DataRow] = ListBuffer()) extends ExtendedQueryState
+
+case class AwaitRowDescription(types: IndexedSeq[Int]) extends ExtendedQueryState
+
+case class EmitOnReadyForQuery[R <: PgResponse](emit: R) extends ExtendedQueryState

--- a/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
@@ -24,7 +24,7 @@ object Arrays {
 
     def apply(str: String) = parseAll(root, str) match {
       case Success(strings, _) => Return(strings)
-      case Failure(_, _) => Throw(new Exception("Failed to parse array string"))
+      case Failure(_, _) | Error(_, _) => Throw(new Exception("Failed to parse array string"))
     }
 
   }


### PR DESCRIPTION
I did this because currently, if there's an error during an extended
query message flow, we must issue a `Sync` in order to get Postgres to
respond to any further messages. However, the state machine currently
does not allow for a Sync message in any state but `Connected`. This
results in a connection hang in some situations.

This change allows `Sync` during any of the extended query states.
