### PR TITLE
Expose service availability in rich client

### DIFF
--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.postgres.generic
 
 import java.nio.charset.Charset
 
+import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres._
 import com.twitter.finagle.postgres.values.ValueDecoder
@@ -46,6 +47,10 @@ class QuerySpec extends FreeSpec with Matchers with MockFactory {
     def inTransaction[T](fn: (PostgresClient) => Future[T]): Future[T] = ???
 
     def query(sql: String): Future[QueryResponse] = ???
+
+    def status: Status = Status.Open
+
+    def isAvailable: Boolean = status == Status.Open
 
   }
 

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.postgres
 import java.nio.charset.Charset
 
+import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres.values.Types
 import com.twitter.util.Future
@@ -62,6 +63,17 @@ trait PostgresClient {
     * @return
     */
   def close(): Future[Unit]
+
+  /**
+   * The current availability [[Status]] of this client.
+   */
+  def status: Status
+
+  /**
+   * Determines whether this client is available (can accept requests
+   * with a reasonable likelihood of success).
+   */
+  def isAvailable: Boolean
 }
 
 

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.Queue
 import scala.language.implicitConversions
 import scala.util.Random
 
+import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.codec.Errors
 import com.twitter.finagle.postgres.messages._
 import com.twitter.finagle.postgres.values._
@@ -175,6 +176,17 @@ class PostgresClientImpl(
   override def close(): Future[Unit] = {
     factory.close()
   }
+
+  /**
+   * The current availability [[Status]] of this client.
+   */
+  override def status: Status = factory.status
+
+  /**
+   * Determines whether this client is available (can accept requests
+   * with a reasonable likelihood of success).
+   */
+  override def isAvailable: Boolean = status == Status.Open
 
   private[this] def sendQuery[T](sql: String)(handler: PartialFunction[PgResponse, Future[T]]) = {
     send(PgRequest(Query(sql)))(handler)

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -5,7 +5,7 @@ import java.time.{Instant, ZoneId, ZonedDateTime}
 
 import com.twitter.finagle.postgres.codec.ServerError
 import com.twitter.finagle.postgres.{OK, PostgresClient, Row, Spec}
-import com.twitter.finagle.Postgres
+import com.twitter.finagle.{Postgres, Status}
 import com.twitter.util.{Await, Duration}
 
 object IntegrationSpec {
@@ -44,6 +44,15 @@ class IntegrationSpec extends Spec {
         .withSessionPool.maxSize(1)
         .conditionally(useSsl, _.withTransport.tlsWithoutValidation)
         .newRichClient(hostPort)
+    }
+
+    def getBadClient = {
+      Postgres.Client()
+        .withCredentials(user, password)
+        .database(dbname)
+        .withSessionPool.maxSize(1)
+        .conditionally(useSsl, _.withTransport.tlsWithoutValidation)
+        .newRichClient("badhost:5432")
     }
 
     def cleanDb(client: PostgresClient): Unit = {
@@ -398,6 +407,25 @@ class IntegrationSpec extends Spec {
             )
           }
 
+        }
+      }
+
+      "return correct availability information" when {
+        "client is good" in {
+          val client: PostgresClient = getClient
+          client.isAvailable must equal(true)
+          client.status must equal(Status.Open)
+        }
+        "client is bad" in {
+          val badClient: PostgresClient = getBadClient
+          badClient.isAvailable must equal(false)
+          badClient.status must equal(Status.Busy)
+        }
+        "client is closed" in {
+          val client: PostgresClient = getClient
+          client.close()
+          client.isAvailable must equal(false)
+          client.status must equal(Status.Closed)
         }
       }
     }


### PR DESCRIPTION
Primitive Finagle services and service factories expose availability information which should be available from the high-level client so things like health checks can be based on it.