### PR TITLE
JSON in types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 
 scala:
@@ -6,6 +7,9 @@ scala:
 
 jdk:
   - oraclejdk8
+
+addons:
+  postgresql: "9.5"
 
 services:
   - postgresql

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ val baseSettings = Seq(
     "com.twitter" %% "finagle-netty3" % "18.2.0",
     "org.scalatest" %% "scalatest" % "3.0.4" % "test,it",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test,it",
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test,it"
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test,it",
+    "io.circe" %% "circe-testing" % "0.8.0" % "test,it"
   )
 )
 

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
@@ -81,7 +81,7 @@ object PostgresClient {
 
   case class TypeSpecifier(receiveFunction: String, typeName: String, elemOid: Long = 0)
 
-  private[finagle] val defaultTypes = Map(
+  val defaultTypes = Map(
     Types.BOOL -> TypeSpecifier("boolrecv", "bool"),
     Types.BYTE_A -> TypeSpecifier("bytearecv", "bytea"),
     Types.CHAR -> TypeSpecifier("charrecv", "char"),
@@ -95,6 +95,7 @@ object PostgresClient {
     Types.TID -> TypeSpecifier("tidrecv", "tid"),
     Types.XID -> TypeSpecifier("xidrecv", "xid"),
     Types.CID -> TypeSpecifier("cidrecv", "cid"),
+    Types.JSON -> TypeSpecifier("json_recv", "json"),
     Types.XML -> TypeSpecifier("xml_recv", "xml"),
     Types.POINT -> TypeSpecifier("point_recv", "point"),
     Types.L_SEG -> TypeSpecifier("lseg_recv", "lseg"),

--- a/src/main/scala/com/twitter/finagle/postgres/values/Types.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Types.scala
@@ -17,6 +17,7 @@ object Types {
   val TID = 27
   val XID = 28
   val CID = 29
+  val JSON = 114
   val XML = 142
   val POINT = 600
   val L_SEG = 601


### PR DESCRIPTION
Adds a mapping for json to default type mappings and makes them public. Right now, I've had to duplicate the whole thing into my code, add json to it, and use `withCustomTypes`. Why not let `finagle-postgres` query the database for the types at startup? Well.. right now there's a bug such that failures to pull the type-map at startup get memoized in a `Future`, causing your client to be dead forever (which I intend to fix in a subsequent pull request).