### PR TITLE
update build and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,17 +3,18 @@ import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.4.1",
-  scalaVersion := "2.11.8"
+  version := "0.4.2",
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.11.8","2.12.1")
 )
 
 val baseSettings = Seq(
   resolvers += Resolver.bintrayRepo("jeremyrsmith", "maven"),
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-core" % "6.39.0",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test,it",
+    "com.twitter" %% "finagle-core" % "6.41.0",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test,it",
     "org.scalacheck" %% "scalacheck" % "1.13.4" % "test,it",
-    "io.github.jeremyrsmith" %% "scalamock-scalatest-support" % "3.0.0" % "test,it"
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test,it"
   )
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers ++= Seq(
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.6")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")


### PR DESCRIPTION
update to use scala 2.11 with finagle 6.41 and then
scalamock-scalatest-support 3.4.2. This needs to wait until patchless
has been updated to 2.12 (which I have an open pr to do
https://github.com/jeremyrsmith/patchless/pull/2 )