### PR TITLE
Migrate to sbt 1.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbtunidoc.Plugin.UnidocKeys._
-import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
@@ -71,26 +69,27 @@ val tutPath = settingKey[String]("Path to tutorials")
 
 lazy val docs = project
   .settings(moduleName := "finagle-postgres-docs", buildSettings)
+  .enablePlugins(GhpagesPlugin, TutPlugin, ScalaUnidocPlugin)
   .settings(
-    tutSettings ++ unidocSettings ++ ghpages.settings ++ Seq(
-      scaladocVersionPath := ("api/" + version.value),
-      scaladocLatestPath := (if (isSnapshot.value) "api/latest-snapshot" else "api/latest"),
-      tutPath := "doc",
-      includeFilter in makeSite := (includeFilter in makeSite).value || "*.md" || "*.yml",
-      addMappingsToSiteDir(tut in Compile, tutPath),
-      addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), scaladocLatestPath),
-      addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), scaladocVersionPath),
-      ghpagesNoJekyll := false,
-      git.remoteRepo := "git@github.com:finagle/finagle-postgres"
-    )
+    scaladocVersionPath := ("api/" + version.value),
+    scaladocLatestPath := (if (isSnapshot.value) "api/latest-snapshot" else "api/latest"),
+    tutPath := "doc",
+    includeFilter in makeSite := (includeFilter in makeSite).value || "*.md" || "*.yml",
+    addMappingsToSiteDir(tut in Compile, tutPath),
+    addMappingsToSiteDir(mappings in(ScalaUnidoc, packageDoc), scaladocLatestPath),
+    addMappingsToSiteDir(mappings in(ScalaUnidoc, packageDoc), scaladocVersionPath),
+    ghpagesNoJekyll := false,
+    git.remoteRepo := "git@github.com:finagle/finagle-postgres"
+
   ).dependsOn(`finagle-postgres`, `finagle-postgres-shapeless`)
+
+
 
 parallelExecution in Test := false
 
 test in Test in `finagle-postgres` := {
   (test in Test in `finagle-postgres`).value
   (test in Test in `finagle-postgres-shapeless`).value
-  (tut in Compile in docs).value
 }
 
 scalacOptions ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,12 +3,12 @@ resolvers ++= Seq(
   Classpaths.sbtPluginReleases
 )
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.1.0")
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")


### PR DESCRIPTION
Problem
The version of plugins and SBT are too old.

Solution
Migrate to sbt 1.0.3

Result
The project is more up to date.