### PR TITLE
Jsonb encoder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,8 @@ lazy val docs = project
 
 parallelExecution in Test := false
 
+javaOptions in Test += "-Duser.timezone=UTC"
+
 test in Test in `finagle-postgres` := {
   (test in Test in `finagle-postgres`).value
   (test in Test in `finagle-postgres-shapeless`).value

--- a/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
@@ -1,4 +1,10 @@
 package com.twitter.finagle.postgres.values
 
+object JSONB {
+  def apply(string: String): JSONB = new JSONB(string.getBytes())
+
+  def stringify(jsonb: JSONB): String = new String(jsonb.bytes)
+}
+
 case class JSONB(bytes: Array[Byte]) extends AnyVal
 

--- a/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
@@ -1,9 +1,11 @@
 package com.twitter.finagle.postgres.values
 
-object JSONB {
-  def apply(string: String): JSONB = new JSONB(string.getBytes())
+import java.nio.charset.Charset
 
-  def stringify(jsonb: JSONB): String = new String(jsonb.bytes)
+object JSONB {
+  def apply(string: String, charset: Charset = Charset.defaultCharset): JSONB = new JSONB(string.getBytes(charset))
+
+  def stringify(jsonb: JSONB, charset: Charset = Charset.defaultCharset): String = new String(jsonb.bytes, charset)
 }
 
 case class JSONB(bytes: Array[Byte]) extends AnyVal

--- a/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/JSONB.scala
@@ -1,0 +1,4 @@
+package com.twitter.finagle.postgres.values
+
+case class JSONB(bytes: Array[Byte]) extends AnyVal
+

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueDecoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueDecoder.scala
@@ -139,11 +139,11 @@ object ValueDecoder {
 
   implicit val javaBigDecimal: ValueDecoder[java.math.BigDecimal] = bigDecimal.map(_.bigDecimal)
 
-  val jsonb = instance(
-    s => Return(s),
+  implicit val jsonb: ValueDecoder[JSONB] = instance(
+    s => Return(JSONB(s)),
     (b, c) => Try {
       b.readByte()  //discard version number
-      new String(Array.fill(b.readableBytes())(b.readByte()), c)
+      JSONB(new String(Array.fill(b.readableBytes())(b.readByte()), c))
     }
   )
 

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -1,14 +1,14 @@
 package com.twitter.finagle.postgres.values
 
-import java.net.InetAddress
-import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.time._
 import java.time.temporal.JulianFields
 import java.util.UUID
 
-import com.twitter.util.{Return, Throw, Try}
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import org.jboss.netty.buffer.ChannelBuffer
+import org.jboss.netty.buffer.ChannelBuffers
 
 import scala.language.existentials
 
@@ -188,6 +188,17 @@ object ValueEncoder extends LowPriorityEncoder {
   implicit val hstoreNoNulls: ValueEncoder[Map[String, String]] = hstore.contraMap {
     m: Map[String, String] => m.mapValues(Option(_))
   }
+
+  implicit val jsonb: ValueEncoder[Array[Byte]] = instance[Array[Byte]](
+    "jsonb",
+    j => String.valueOf(j),
+    (j, c) => {
+      val cb = ChannelBuffers.buffer(1 + j.length)
+      cb.writeByte(1)
+      cb.writeBytes(j)
+      Some(cb)
+    }
+  )
 
   @inline final implicit def option[T](implicit encodeT: ValueEncoder[T]): ValueEncoder[Option[T]] =
     new ValueEncoder[Option[T]] {

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -222,5 +222,3 @@ object ValueEncoder extends LowPriorityEncoder {
 trait LowPriorityEncoder {
   implicit def fromExport[T](implicit export: ValueEncoder.Exported[T]): ValueEncoder[T] = export.encoder
 }
-
-case class JSONB(bytes: Array[Byte]) extends AnyVal

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -191,7 +191,7 @@ object ValueEncoder extends LowPriorityEncoder {
 
   implicit val jsonb: ValueEncoder[JSONB] = instance[JSONB](
     "jsonb",
-    j => String.valueOf(j),
+    j => JSONB.stringify(j),
     (j, c) => {
       val cb = ChannelBuffers.buffer(1 + j.bytes.length)
       cb.writeByte(1)

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -189,13 +189,13 @@ object ValueEncoder extends LowPriorityEncoder {
     m: Map[String, String] => m.mapValues(Option(_))
   }
 
-  implicit val jsonb: ValueEncoder[Array[Byte]] = instance[Array[Byte]](
+  implicit val jsonb: ValueEncoder[JSONB] = instance[JSONB](
     "jsonb",
     j => String.valueOf(j),
     (j, c) => {
-      val cb = ChannelBuffers.buffer(1 + j.length)
+      val cb = ChannelBuffers.buffer(1 + j.bytes.length)
       cb.writeByte(1)
-      cb.writeBytes(j)
+      cb.writeBytes(j.bytes)
       Some(cb)
     }
   )
@@ -222,3 +222,5 @@ object ValueEncoder extends LowPriorityEncoder {
 trait LowPriorityEncoder {
   implicit def fromExport[T](implicit export: ValueEncoder.Exported[T]): ValueEncoder[T] = export.encoder
 }
+
+case class JSONB(bytes: Array[Byte]) extends AnyVal

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -1,12 +1,16 @@
 package com.twitter.finagle.postgres.integration
 
 import java.sql.Timestamp
-import java.time.{Instant, ZoneId, ZonedDateTime}
+import java.time.Instant
 
-import com.twitter.finagle.postgres.codec.ServerError
 import com.twitter.finagle.postgres._
-import com.twitter.finagle.{Postgres, Status}
-import com.twitter.util.{Await, Duration, Future, Promise}
+import com.twitter.finagle.postgres.codec.ServerError
+import com.twitter.finagle.Postgres
+import com.twitter.finagle.Status
+import com.twitter.util.Try
+import com.twitter.util.Await
+import com.twitter.util.Duration
+import com.twitter.util.Future
 
 object IntegrationSpec {
   val pgTestTable = "finagle_test"
@@ -78,6 +82,8 @@ class IntegrationSpec extends Spec {
       """.stripMargin.format(IntegrationSpec.pgTestTable))
       val response2 = Await.result(createTableQuery, queryTimeout)
       response2 must equal(OK(1))
+
+      Try(Await.result(client.execute("create extension hstore"))) // enable hstore type
     }
 
     def insertSampleData(client: PostgresClient): Unit = {

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -145,7 +145,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
       "parse jsonb" in {
         val json = "{\"a\":\"b\"}"
         val createBuffer = () => {
-          ValueEncoder.jsonb.encodeBinary(json.getBytes, Charset.defaultCharset()).get
+          ValueEncoder.jsonb.encodeBinary(JSONB(json.getBytes), Charset.defaultCharset()).get
         }
         val buffer = createBuffer()
         val version = buffer.readByte()

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -145,7 +145,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
       "parse jsonb" in {
         val json = "{\"a\":\"b\"}"
         val createBuffer = () => {
-          ValueEncoder.jsonb.encodeBinary(JSONB(json.getBytes), Charset.defaultCharset()).get
+          ValueEncoder[JSONB].encodeBinary(JSONB(json.getBytes), Charset.defaultCharset()).get
         }
         val buffer = createBuffer()
         val version = buffer.readByte()
@@ -153,8 +153,8 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
         version must equal(1)
         encoded must equal(json.getBytes)
 
-        val decoded = ValueDecoder.jsonb.decodeBinary("", createBuffer(), Charset.defaultCharset()).get()
-        decoded must equal(json)
+        val decoded = ValueDecoder[JSONB].decodeBinary("", createBuffer(), Charset.defaultCharset()).get()
+        JSONB.stringify(decoded) must equal(json)
       }
     }
   }


### PR DESCRIPTION
Problem
Can't insert `jsonb` columns without a custom encoder

Solution
Create a `jsonb` encoder that accepts an `Array[Byte]`

Result
`jsonb` columns can now be inserted. 

But with a caveat: the client must `import ValueEncoder.jsonb`. I couldn't find the mechanism to make the the encoders available to the implicit conversion.

I also added more two things: `hstore` extension creation in the `IntegrationTest` and UTC user timezone definitions for tests. 

Any feedback is highly appreciated. Thanks a lot for building this library :)