### PR TITLE
adds listen/notify support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,8 @@ lazy val docs = project
 
 parallelExecution in Test := false
 
+javaOptions in Test += "-Duser.timezone=UTC"
+
 test in Test in `finagle-postgres` := {
   (test in Test in `finagle-postgres`).value
   (test in Test in `finagle-postgres-shapeless`).value

--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
@@ -2,9 +2,11 @@ package com.twitter.finagle.postgres.generic
 
 import java.nio.charset.Charset
 
+import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres._
+import com.twitter.finagle.postgres.messages.Listener
 import com.twitter.finagle.postgres.messages.NotificationResponse
 import com.twitter.finagle.postgres.values.ValueDecoder
 import com.twitter.util.{Await, Future}
@@ -53,7 +55,7 @@ class QuerySpec extends FreeSpec with Matchers with MockFactory {
 
     def isAvailable: Boolean = status == Status.Open
 
-    def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable] = ???
+    def listen(channel: String): Future[Listener] = ???
 
     def unlisten(channel: String): Future[QueryResponse] = ???
   }

--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/QuerySpec.scala
@@ -5,6 +5,7 @@ import java.nio.charset.Charset
 import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres._
+import com.twitter.finagle.postgres.messages.NotificationResponse
 import com.twitter.finagle.postgres.values.ValueDecoder
 import com.twitter.util.{Await, Future}
 import org.scalamock.scalatest.MockFactory
@@ -52,6 +53,9 @@ class QuerySpec extends FreeSpec with Matchers with MockFactory {
 
     def isAvailable: Boolean = status == Status.Open
 
+    def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable] = ???
+
+    def unlisten(channel: String): Future[QueryResponse] = ???
   }
 
   def expectQuery[U](expectedQuery: String, expectedParams: Param[_]*)(query: Query[U]) = {

--- a/src/main/scala/com/twitter/finagle/Postgres.scala
+++ b/src/main/scala/com/twitter/finagle/Postgres.scala
@@ -14,9 +14,14 @@ import com.twitter.finagle.service._
 import com.twitter.finagle.ssl.client.SslClientEngineFactory
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.transport.{Transport, TransportContext}
-import com.twitter.util.{Monitor => _, _}
 import com.twitter.logging.Logger
 import java.net.SocketAddress
+
+import com.twitter.util.Duration
+import com.twitter.util.Future
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import com.twitter.util.Try
 import org.jboss.netty.channel.{ChannelPipelineFactory, Channels}
 
 import scala.language.existentials
@@ -83,6 +88,7 @@ object Postgres {
         pipeline.addLast("binary_to_packet", new PacketDecoder(ssl.nonEmpty))
         pipeline.addLast("packet_to_backend_messages", new BackendMessageDecoder(new BackendMessageParser))
         pipeline.addLast("backend_messages_to_postgres_response", new PgClientChannelHandler(sslFactory, ssl, ssl.nonEmpty))
+        pipeline.addLast("notifications", new NotificationHandler)
         pipeline
       }
     }

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.postgres
 import java.nio.charset.Charset
 
 import com.twitter.finagle.Status
-import com.twitter.finagle.postgres.messages.NotificationResponse
+import com.twitter.finagle.postgres.messages.Listener
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres.values.Types
 import com.twitter.util.Future
@@ -79,10 +79,9 @@ trait PostgresClient {
   /**
     * Starts listening to the given channel and registers the consumer
     * @param channel the name of the channel
-    * @param block the consumer that accepts a [[NotificationResponse]]
-    * @return a function to stop consuming notifications
+    * @return a [[Listener]]
     */
-  def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable]
+  def listen(channel: String): Future[Listener]
 
   /**
     * Stops listening for notifications

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClient.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.postgres
 import java.nio.charset.Charset
 
 import com.twitter.finagle.Status
+import com.twitter.finagle.postgres.messages.NotificationResponse
 import com.twitter.finagle.postgres.messages.SelectResult
 import com.twitter.finagle.postgres.values.Types
 import com.twitter.util.Future
@@ -74,6 +75,21 @@ trait PostgresClient {
    * with a reasonable likelihood of success).
    */
   def isAvailable: Boolean
+
+  /**
+    * Starts listening to the given channel and registers the consumer
+    * @param channel the name of the channel
+    * @param block the consumer that accepts a [[NotificationResponse]]
+    * @return a function to stop consuming notifications
+    */
+  def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable]
+
+  /**
+    * Stops listening for notifications
+    * @param channel the name of the channel
+    * @return the query (UNLISTEN) result
+    */
+  def unlisten(channel: String): Future[QueryResponse]
 }
 
 

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
@@ -4,11 +4,11 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
 
+import com.twitter.finagle.Service
+import com.twitter.finagle.ServiceFactory
 import com.twitter.finagle.Status
 import com.twitter.finagle.postgres.messages._
 import com.twitter.finagle.postgres.values._
-import com.twitter.finagle.Service
-import com.twitter.finagle.ServiceFactory
 import com.twitter.logging.Logger
 import com.twitter.util._
 import org.jboss.netty.buffer.ChannelBuffer
@@ -187,11 +187,11 @@ class PostgresClientImpl(
    */
   override def isAvailable: Boolean = status == Status.Open
 
-  override def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable] = {
+  override def listen(channel: String): Future[Listener] = {
     if(Listeners.alreadyListening(channel)) {
-      return Future(Listeners.addConsumer(channel, block))
+      return Future(Listeners.addConsumer(channel))
     }
-    query(s"LISTEN $channel").map(_ => Listeners.addConsumer(channel, block))
+    query(s"LISTEN $channel").map(_ => Listeners.addConsumer(channel))
   }
 
   override def unlisten(channel: String): Future[QueryResponse] = {

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -242,6 +242,8 @@ class BackendMessageParser {
           case "RELEASE" => Release
           case "ROLLBACK"  => RollBack
           case "COMMIT" => Commit
+          case "LISTEN" => Listen
+          case "UNLISTEN" => UnListen
           case _ => throw new IllegalStateException("Unknown command complete response tag " + tag)
         }
     }

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
@@ -83,6 +83,10 @@ case object RollBack extends CommandCompleteStatus
 
 case object Commit extends CommandCompleteStatus
 
+case object Listen extends CommandCompleteStatus
+
+case object UnListen extends CommandCompleteStatus
+
 case class CommandComplete(status: CommandCompleteStatus) extends BackendMessage
 
 case class ReadyForQuery(status: Char) extends BackendMessage

--- a/src/main/scala/com/twitter/finagle/postgres/messages/NotificationHandler.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/NotificationHandler.scala
@@ -1,17 +1,18 @@
 package com.twitter.finagle.postgres.messages
 
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.function
 import java.util.function.BiFunction
 
+import com.twitter.concurrent.AsyncStream
 import com.twitter.logging.Logger
+import com.twitter.util.Promise
 import org.jboss.netty.channel.ChannelHandler.Sharable
 import org.jboss.netty.channel.ChannelHandlerContext
 import org.jboss.netty.channel.MessageEvent
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler
 
 import scala.collection.parallel.mutable
-import scala.collection.parallel.mutable.ParSet
 
 @Sharable
 class NotificationHandler extends SimpleChannelUpstreamHandler() {
@@ -23,42 +24,72 @@ class NotificationHandler extends SimpleChannelUpstreamHandler() {
   }
 }
 
+object Listener {
+  def unapply(l: Listener) = Some((l.stream, () => l.stop()))
+}
+
+trait Listener {
+  def stream: AsyncStream[NotificationResponse]
+  def stop(): Unit
+}
+
+case class NextPromise(id: UUID, value: Promise[NotificationResponse])
+
 object Listeners {
 
   private[this] val logger = Logger(getClass)
 
-  private val map: ConcurrentHashMap[String, mutable.ParSet[NotificationResponse => Unit]] = new ConcurrentHashMap()
+  private val map: ConcurrentHashMap[String, List[NextPromise]] = new ConcurrentHashMap()
+  private val listeners = mutable.ParSet[UUID]()
 
   def alreadyListening(channel: String): Boolean = map.containsKey(channel)
 
-  def addConsumer(channel: String, block: Function[NotificationResponse, Unit]): Runnable = {
-    map.computeIfAbsent(channel, firstConsumer)
-    map.computeIfPresent(channel, addConsumer(block))
-    new Runnable {
-      override def run(): Unit = map.computeIfPresent(channel, removeConsumer(block))
+  def addConsumer(channel: String, id: UUID = UUID.randomUUID()): Listener = {
+    val p = NextPromise(id, Promise[NotificationResponse])
+    listeners += id
+    map.compute(channel, addPromise(p))
+    createListener(channel, id, createStream(channel, p))
+  }
+
+  private def createListener(channel: String, id: UUID, msgStream: AsyncStream[NotificationResponse]) = {
+    new Listener {
+      override def stream: AsyncStream[NotificationResponse] = msgStream
+      override def stop(): Unit = {
+        map.computeIfPresent(channel, removePromise(id))
+        listeners - id
+      }
     }
   }
 
-  def removeAllConsumers(channel: String): Unit = map.remove(channel)
+  private def createStream(channel: String, p: NextPromise) = {
+    AsyncStream.fromFuture(p.value) ++ {
+      if (listeners.contains(p.id))
+        addConsumer(channel, p.id).stream
+      else
+        AsyncStream.empty
+    }
+  }
+
+  def removeAllConsumers(channel: String): Unit = {
+    listeners.clear()
+    map.remove(channel)
+  }
 
   def notify(msg: NotificationResponse): Unit = {
-    logger.ifDebug(() => s"Notifying listeners with message $msg")
-    Option(map.get(msg.channel)).foreach(_.foreach(_.apply(msg)))
+      val clients = map.remove(msg.channel)
+      map.putIfAbsent(msg.channel, List())
+      clients.filterNot(_.value.isDefined).foreach(_.value.setValue(msg))
   }
 
-  private val firstConsumer = new function.Function[String, ParSet[NotificationResponse => Unit]] {
-    override def apply(t: String): ParSet[NotificationResponse => Unit] = mutable.ParSet.empty
-  }
-
-  private def addConsumer(block: Function[NotificationResponse, Unit]) = new BiFunction[String, ParSet[NotificationResponse => Unit], ParSet[NotificationResponse => Unit]] {
-    override def apply(t: String, u: ParSet[NotificationResponse => Unit]): ParSet[NotificationResponse => Unit] = {
-      u + block
+  private def addPromise(p: NextPromise) = new BiFunction[String, List[NextPromise], List[NextPromise]] {
+    override def apply(t: String, u: List[NextPromise]): List[NextPromise] = {
+      p :: Option(u).getOrElse(List())
     }
   }
 
-  private def removeConsumer(block: Function[NotificationResponse, Unit]) = new BiFunction[String, ParSet[NotificationResponse => Unit], ParSet[NotificationResponse => Unit]] {
-    override def apply(t: String, u: ParSet[NotificationResponse => Unit]): ParSet[NotificationResponse => Unit] = {
-      u - block
+  private def removePromise(id: UUID) = new BiFunction[String, List[NextPromise], List[NextPromise]] {
+    override def apply(t: String, u: List[NextPromise]): List[NextPromise] = {
+      u.filterNot(_.id == id)
     }
   }
 }

--- a/src/main/scala/com/twitter/finagle/postgres/messages/NotificationHandler.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/NotificationHandler.scala
@@ -1,0 +1,64 @@
+package com.twitter.finagle.postgres.messages
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function
+import java.util.function.BiFunction
+
+import com.twitter.logging.Logger
+import org.jboss.netty.channel.ChannelHandler.Sharable
+import org.jboss.netty.channel.ChannelHandlerContext
+import org.jboss.netty.channel.MessageEvent
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler
+
+import scala.collection.parallel.mutable
+import scala.collection.parallel.mutable.ParSet
+
+@Sharable
+class NotificationHandler extends SimpleChannelUpstreamHandler() {
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent): Unit = {
+    e.getMessage match {
+      case SingleMessageResponse(n: NotificationResponse) => Listeners.notify(n)
+      case _ => super.messageReceived(ctx, e)
+    }
+  }
+}
+
+object Listeners {
+
+  private[this] val logger = Logger(getClass)
+
+  private val map: ConcurrentHashMap[String, mutable.ParSet[NotificationResponse => Unit]] = new ConcurrentHashMap()
+
+  def alreadyListening(channel: String): Boolean = map.containsKey(channel)
+
+  def addConsumer(channel: String, block: Function[NotificationResponse, Unit]): Runnable = {
+    map.computeIfAbsent(channel, firstConsumer)
+    map.computeIfPresent(channel, addConsumer(block))
+    new Runnable {
+      override def run(): Unit = map.computeIfPresent(channel, removeConsumer(block))
+    }
+  }
+
+  def removeAllConsumers(channel: String): Unit = map.remove(channel)
+
+  def notify(msg: NotificationResponse): Unit = {
+    logger.ifDebug(() => s"Notifying listeners with message $msg")
+    Option(map.get(msg.channel)).foreach(_.foreach(_.apply(msg)))
+  }
+
+  private val firstConsumer = new function.Function[String, ParSet[NotificationResponse => Unit]] {
+    override def apply(t: String): ParSet[NotificationResponse => Unit] = mutable.ParSet.empty
+  }
+
+  private def addConsumer(block: Function[NotificationResponse, Unit]) = new BiFunction[String, ParSet[NotificationResponse => Unit], ParSet[NotificationResponse => Unit]] {
+    override def apply(t: String, u: ParSet[NotificationResponse => Unit]): ParSet[NotificationResponse => Unit] = {
+      u + block
+    }
+  }
+
+  private def removeConsumer(block: Function[NotificationResponse, Unit]) = new BiFunction[String, ParSet[NotificationResponse => Unit], ParSet[NotificationResponse => Unit]] {
+    override def apply(t: String, u: ParSet[NotificationResponse => Unit]): ParSet[NotificationResponse => Unit] = {
+      u - block
+    }
+  }
+}

--- a/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionAsyncSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionAsyncSpec.scala
@@ -1,49 +1,35 @@
 package com.twitter.finagle.postgres.connection
 
 import com.twitter.finagle.postgres.Spec
-import com.twitter.finagle.postgres.messages.{Query, ParameterStatus, NotificationResponse, NoticeResponse}
+import com.twitter.finagle.postgres.messages.SingleMessageResponse
+import com.twitter.finagle.postgres.messages.{NoticeResponse, NotificationResponse, ParameterStatus, Query}
 
 class ConnectionAsyncSpec extends Spec {
   "A postgres connection" should {
-    "ignore async messages for new connection" in {
-      val connection = new Connection()
-
-      val response = connection.receive(NotificationResponse(-1, "", ""))
-      response must equal(None)
-
-      val response2 = connection.receive(NoticeResponse(Some("blahblah")))
-      response2 must equal(None)
-
-      val response3 = connection.receive(ParameterStatus("foo", "bar"))
-      response3 must equal(None)
+    "ignore async messages for new connection but accept notification" in {
+      verify(new Connection())
     }
 
-    "ignore async messages for connected client" in {
-      val connection = new Connection(Connected)
-
-      val response = connection.receive(NotificationResponse(-1, "", ""))
-      response must equal(None)
-
-      val response2 = connection.receive(NoticeResponse(Some("blahblah")))
-      response2 must equal(None)
-
-      val response3 = connection.receive(ParameterStatus("foo", "bar"))
-      response3 must equal(None)
+    "ignore async messages for connected client but accept notification" in {
+      verify(new Connection(Connected))
     }
 
-    "ignore async messages when in query" in {
+    "ignore async messages when in query but accept notification" in {
       val connection = new Connection(Connected)
-
       connection.send(Query("select * from Test"))
-
-      val response = connection.receive(NotificationResponse(-1, "", ""))
-      response must equal(None)
-
-      val response2 = connection.receive(NoticeResponse(Some("blahblah")))
-      response2 must equal(None)
-
-      val response3 = connection.receive(ParameterStatus("foo", "bar"))
-      response3 must equal(None)
+      verify(connection)
     }
+  }
+
+  private def verify(connection: Connection) = {
+    val response2 = connection.receive(NoticeResponse(Some("blahblah")))
+    response2 must equal(None)
+
+    val response3 = connection.receive(ParameterStatus("foo", "bar"))
+    response3 must equal(None)
+
+    val not = NotificationResponse(-1, "", "")
+    val response4 = connection.receive(not)
+    response4 must equal(Some(SingleMessageResponse(not)))
   }
 }


### PR DESCRIPTION
Problem
`NotificationResponses` are discarded so the client can't listen for events. 

Solution
1. Replace `NotificationResponse` transition to pass the event down the pipeline:
```scala
transition {
    case (notification: NotificationResponse, s) =>
      logger.ifDebug("Notification from server: %s".format(notification))
      (Some(SingleMessageResponse(notification)), s)
  }
```
2. Add a new channel handler (`NotificationHandler`) that call consumers with received `NotificationResponse`
```scala
pipeline.addLast("notifications", new NotificationHandler)
```
3. Add `listen` and `unlisten` methods to the client:
```scala
  override def listen(channel: String, block: NotificationResponse => Unit): Future[Runnable] = {
    if(Listeners.alreadyListening(channel)) {
      return Future(Listeners.addConsumer(channel, block))
    }
    query(s"LISTEN $channel").map(_ => Listeners.addConsumer(channel, block))
  }

  override def unlisten(channel: String): Future[QueryResponse] = {
    query(s"UNLISTEN $channel").onSuccess(_ => Listeners.removeAllConsumers(channel))
  }
```

Result
clients can now listen for channel events.

This is a bigger PR. Any feedback is highly appreciated. Thanks!