### PR TITLE
Changes default custom receive function to saner defaults

### DIFF
--- a/src/main/scala/com/twitter/finagle/Postgres.scala
+++ b/src/main/scala/com/twitter/finagle/Postgres.scala
@@ -52,7 +52,7 @@ object Postgres {
   object CustomTypes { implicit val param = Param(CustomTypes(None)) }
 
   case class CustomReceiveFunctions(functions: PartialFunction[String, ValueDecoder[T] forSome {type T}]) extends AnyVal
-  object CustomReceiveFunctions { implicit val param = Param(CustomReceiveFunctions(PartialFunction.empty)) }
+  object CustomReceiveFunctions { implicit val param = Param(CustomReceiveFunctions(ValueDecoder.decoders)) }
 
   case class BinaryResults(binaryResults: Boolean) extends AnyVal
   object BinaryResults { implicit val param = Param(BinaryResults(false)) }


### PR DESCRIPTION
I found that methods on `com.twitter.finagle.postgres.RowImpl` objects like `#getAnyOption` failed to parse basic values from Postgres unless the client was instantiated with something like:

```scala
val client = Postgres.Client()
  ...
  .withCustomReceiveFunctions(ValueDecoder.decoders)
  .newRichClient("host:port")
```

Meanwhile, importing all the `implicit` decoders from `ValueDecoders` and using `RowImpl#getOption` (which expects to be passed the decoder as an implicit argument) instead of `#getAnyOption` seemed to work fine.

I believe this is because the default data type to decoder mapping is blank:

```scala
  case class CustomReceiveFunctions(functions: PartialFunction[String, ValueDecoder[T] forSome {type T}]) extends AnyVal
  object CustomReceiveFunctions { implicit val param = Param(CustomReceiveFunctions(PartialFunction.empty)) }
```

This change makes the default `ValueDecoder.decoders`, which I believe has all the Postgres default datatypes.