### PR TITLE
Upgrade to Netty 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val baseSettings = Seq(
   resolvers += Resolver.bintrayRepo("jeremyrsmith", "maven"),
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-core" % "18.2.0",
-    "com.twitter" %% "finagle-netty3" % "18.2.0",
+    "com.twitter" %% "finagle-netty4" % "18.2.0",
     "org.scalatest" %% "scalatest" % "3.0.4" % "test,it",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test,it",
     "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test,it"

--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
@@ -64,12 +64,12 @@ class EnumSpec extends FlatSpec with Matchers {
 
   "Enum encoding" should "encode enumeration ADTs to Strings" in {
     val encoder = ValueEncoder[TestEnum]
-    encoder.encodeText(CaseOne) shouldEqual Some("CaseOne")
-    encoder.encodeText(CaseTwo) shouldEqual Some("CaseTwo")
-    encoder.encodeText(CaseThree) shouldEqual Some("CaseThree")
-    encoder.encodeBinary(CaseOne, UTF8).get.toString(UTF8) shouldEqual "CaseOne"
-    encoder.encodeBinary(CaseTwo, UTF8).get.toString(UTF8) shouldEqual "CaseTwo"
-    encoder.encodeBinary(CaseThree, UTF8).get.toString(UTF8) shouldEqual "CaseThree"
+    encoder.encodeText(CaseOne, ) shouldEqual Some("CaseOne")
+    encoder.encodeText(CaseTwo, ) shouldEqual Some("CaseTwo")
+    encoder.encodeText(CaseThree, ) shouldEqual Some("CaseThree")
+    encoder.encodeBinary(CaseOne, UTF8, ).get.toString(UTF8) shouldEqual "CaseOne"
+    encoder.encodeBinary(CaseTwo, UTF8, ).get.toString(UTF8) shouldEqual "CaseTwo"
+    encoder.encodeBinary(CaseThree, UTF8, ).get.toString(UTF8) shouldEqual "CaseThree"
   }
 
 }

--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
@@ -5,7 +5,8 @@ import java.nio.charset.StandardCharsets
 import com.twitter.finagle.postgres.generic.enumeration.InvalidValue
 import com.twitter.finagle.postgres.values.{ValueDecoder, ValueEncoder}
 import com.twitter.util.{Return, Throw}
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.{Unpooled, UnpooledByteBufAllocator}
+
 import org.scalatest.{FlatSpec, Matchers}
 
 
@@ -21,6 +22,7 @@ class EnumSpec extends FlatSpec with Matchers {
 
   val UTF8 = StandardCharsets.UTF_8
 
+  private val allocator = UnpooledByteBufAllocator.DEFAULT
 
   "Enum decoding" should "decode enumeration ADTs from strings" in  {
 
@@ -32,19 +34,19 @@ class EnumSpec extends FlatSpec with Matchers {
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseOne", UTF8),
+      Unpooled.copiedBuffer("CaseOne", UTF8),
       UTF8
     ) shouldEqual Return(CaseOne)
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseTwo", UTF8),
+      Unpooled.copiedBuffer("CaseTwo", UTF8),
       UTF8
     ) shouldEqual Return(CaseTwo)
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseThree", UTF8),
+      Unpooled.copiedBuffer("CaseThree", UTF8),
       UTF8
     ) shouldEqual Return(CaseThree)
 
@@ -56,7 +58,7 @@ class EnumSpec extends FlatSpec with Matchers {
     decoder.decodeText("enum_recv", "CasePurple") shouldEqual Throw(InvalidValue("CasePurple"))
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CasePurple", UTF8),
+      Unpooled.copiedBuffer("CasePurple", UTF8),
       UTF8
     ) shouldEqual Throw(InvalidValue("CasePurple"))
 
@@ -64,12 +66,12 @@ class EnumSpec extends FlatSpec with Matchers {
 
   "Enum encoding" should "encode enumeration ADTs to Strings" in {
     val encoder = ValueEncoder[TestEnum]
-    encoder.encodeText(CaseOne, ) shouldEqual Some("CaseOne")
-    encoder.encodeText(CaseTwo, ) shouldEqual Some("CaseTwo")
-    encoder.encodeText(CaseThree, ) shouldEqual Some("CaseThree")
-    encoder.encodeBinary(CaseOne, UTF8, ).get.toString(UTF8) shouldEqual "CaseOne"
-    encoder.encodeBinary(CaseTwo, UTF8, ).get.toString(UTF8) shouldEqual "CaseTwo"
-    encoder.encodeBinary(CaseThree, UTF8, ).get.toString(UTF8) shouldEqual "CaseThree"
+    encoder.encodeText(CaseOne) shouldEqual Some("CaseOne")
+    encoder.encodeText(CaseTwo) shouldEqual Some("CaseTwo")
+    encoder.encodeText(CaseThree) shouldEqual Some("CaseThree")
+    encoder.encodeBinary(CaseOne, UTF8, allocator).get.toString(UTF8) shouldEqual "CaseOne"
+    encoder.encodeBinary(CaseTwo, UTF8, allocator).get.toString(UTF8) shouldEqual "CaseTwo"
+    encoder.encodeBinary(CaseThree, UTF8, allocator).get.toString(UTF8) shouldEqual "CaseThree"
   }
 
 }

--- a/src/main/scala/com/twitter/finagle/Postgres.scala
+++ b/src/main/scala/com/twitter/finagle/Postgres.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.Stack.{Param, Params, Role}
 import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
 import com.twitter.finagle.dispatch.SerialClientDispatcher
 import com.twitter.finagle.naming.BindingFactory.Dest
-import com.twitter.finagle.netty3.Netty3Transporter
+import com.twitter.finagle.netty4.Netty4Transporter
 import com.twitter.finagle.param._
 import com.twitter.finagle.postgres.codec._
 import com.twitter.finagle.postgres.messages._
@@ -17,7 +17,8 @@ import com.twitter.finagle.transport.{Transport, TransportContext}
 import com.twitter.util.{Monitor => _, _}
 import com.twitter.logging.Logger
 import java.net.SocketAddress
-import org.jboss.netty.channel.{ChannelPipelineFactory, Channels}
+
+import io.netty.channel.ChannelPipeline
 
 import scala.language.existentials
 
@@ -72,24 +73,20 @@ object Postgres {
     .replace(StackClient.Role.prepConn, PrepConnection)
     .replace(Retries.Role, Retries.moduleWithRetryPolicy[PgRequest, PgResponse])
 
-  private def pipelineFactory(params: Stack.Params) = {
+  private def pipelineFactory(params: Stack.Params)(pipeline: ChannelPipeline) = {
     val SslClientEngineFactory.Param(sslFactory) = params[SslClientEngineFactory.Param]
     val Transport.ClientSsl(ssl) = params[Transport.ClientSsl]
-
-    new ChannelPipelineFactory {
-      def getPipeline = {
-        val pipeline = Channels.pipeline()
 
         pipeline.addLast("binary_to_packet", new PacketDecoder(ssl.nonEmpty))
         pipeline.addLast("packet_to_backend_messages", new BackendMessageDecoder(new BackendMessageParser))
         pipeline.addLast("backend_messages_to_postgres_response", new PgClientChannelHandler(sslFactory, ssl, ssl.nonEmpty))
-        pipeline
-      }
-    }
+
+
+
   }
 
   private def mkTransport(params: Stack.Params, addr: SocketAddress) =
-    Netty3Transporter.apply[PgRequest, PgResponse](
+    Netty4Transporter.raw[PgRequest, PgResponse](
       pipelineFactory(params),
       addr,
       params + Transport.ClientSsl(None)  // we want to give this param to Postgres but not directly to transport

--- a/src/main/scala/com/twitter/finagle/postgres/Responses.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Responses.scala
@@ -4,14 +4,13 @@ import java.nio.charset.Charset
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import com.twitter.finagle.postgres.messages.{DataRow, Field}
 import com.twitter.finagle.postgres.values.ValueDecoder
 import com.twitter.util.Try
 import Try._
 import com.twitter.finagle.postgres.PostgresClient.TypeSpecifier
 import com.twitter.finagle.postgres.codec.NullValue
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import scala.language.existentials
 
@@ -42,14 +41,14 @@ trait Row {
 }
 
 object Row {
-  def apply(values: Array[Option[ChannelBuffer]], rowFormat: RowFormat): Row = RowImpl(values, rowFormat)
+  def apply(values: Array[Option[ByteBuf]], rowFormat: RowFormat): Row = RowImpl(values, rowFormat)
 }
 
 /*
  * Convenience wrapper around a set of row values. Supports lookup by name.
  */
 case class RowImpl(
-  values: Array[Option[ChannelBuffer]],
+  values: Array[Option[ByteBuf]],
   rowFormat: RowFormat
 ) extends Row {
 

--- a/src/main/scala/com/twitter/finagle/postgres/codec/PgCodec.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/codec/PgCodec.scala
@@ -12,10 +12,9 @@ import com.twitter.logging.Logger
 import com.twitter.util.Future
 import javax.net.ssl.SSLSession
 
-import io.netty.buffer.{ByteBuf, PooledByteBufAllocator}
+import io.netty.buffer.{ByteBuf, ByteBufAllocator}
 import io.netty.channel.{ChannelHandlerContext, ChannelPromise}
 import io.netty.handler.codec.{ByteToMessageDecoder, MessageToMessageCodec, MessageToMessageDecoder}
-
 import com.twitter.finagle.ssl.Ssl
 import io.netty.handler.ssl.SslHandler
 
@@ -163,10 +162,9 @@ class PacketDecoder(@volatile var inSslNegotation: Boolean) extends ByteToMessag
 class PgClientChannelHandler(
   sslEngineFactory: SslClientEngineFactory,
   sslConfig: Option[SslClientConfiguration],
-  val useSsl: Boolean
+  val useSsl: Boolean,
+  allocator: ByteBufAllocator
 ) extends MessageToMessageCodec[BackendMessage, Object] {
-
-  private val allocator = new PooledByteBufAllocator()
 
   private[this] val logger = Logger(getClass.getName)
   private[this] val connection = {

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -2,8 +2,8 @@ package com.twitter.finagle.postgres.messages
 
 import com.twitter.finagle.postgres.values.Buffers
 import com.twitter.logging.Logger
+import io.netty.buffer.ByteBuf
 
-import org.jboss.netty.buffer.ChannelBuffer
 
 /*
  * Class for converting packets into BackendMessages.
@@ -105,8 +105,8 @@ class BackendMessageParser {
   def parseE(packet: Packet): Option[BackendMessage] = {
     val Packet(_, _, content, _) = packet
 
-    def fieldStream(buf: ChannelBuffer):Stream[(Char,String)] =
-      if(buf.readable)
+    def fieldStream(buf: ByteBuf):Stream[(Char,String)] =
+      if(buf.isReadable)
         Buffers.readCString(buf) match {
           case "" => Stream.empty
           case nonempty => (nonempty.splitAt(1) match { case (fieldId, value) => (fieldId.charAt(0), value) }) #:: fieldStream(buf)
@@ -125,7 +125,7 @@ class BackendMessageParser {
       Some(SslNotSupported)
     } else {
       val builder = new StringBuilder()
-      while (content.readable) {
+      while (content.isReadable) {
         builder.append(Buffers.readCString(content))
       }
 
@@ -166,7 +166,7 @@ class BackendMessageParser {
     val Packet(_, _, content, _) = packet
 
     val fieldNumber = content.readShort
-    val fields = new Array[Option[ChannelBuffer]](fieldNumber)
+    val fields = new Array[Option[ByteBuf]](fieldNumber)
 
     for (i <- 0.until(fieldNumber)) {
       val length = content.readInt

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.postgres.messages
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
+
 
 /**
  * Responses sent from Postgres back to the client.
@@ -40,7 +41,7 @@ case class FieldDescription(
     dataTypeModifier: Int,
     fieldFormat: Short)
 
-case class DataRow(data: Array[Option[ChannelBuffer]]) extends BackendMessage
+case class DataRow(data: Array[Option[ByteBuf]]) extends BackendMessage
 
 /*
  * Sub-message types used to complete a command.

--- a/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
@@ -2,9 +2,8 @@ package com.twitter.finagle.postgres.values
 
 import scala.collection.immutable.Queue
 import scala.util.parsing.combinator.RegexParsers
-
 import com.twitter.util.{Return, Throw, Try}
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 object Arrays {
 
   object ArrayStringParser extends RegexParsers {
@@ -40,7 +39,7 @@ object Arrays {
     }
   }
 
-  def decodeArrayBinary[T](buf: ChannelBuffer, elemDecoder: ValueDecoder[T]) = {
+  def decodeArrayBinary[T](buf: ByteBuf, elemDecoder: ValueDecoder[T]) = {
     val ndims = buf.readInt()
     val flags = buf.readInt()
     val elemOid = buf.readInt()

--- a/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
@@ -2,9 +2,9 @@ package com.twitter.finagle.postgres.values
 
 import java.nio.charset.Charset
 
-import scala.util.parsing.combinator.RegexParsers
+import io.netty.buffer.{ByteBuf, ByteBufAllocator}
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import scala.util.parsing.combinator.RegexParsers
 
 object HStores {
   object HStoreStringParser extends RegexParsers {
@@ -36,7 +36,7 @@ object HStores {
       s"""$key => $value"""
   }.mkString(",")
 
-  def decodeHStoreBinary(buf: ChannelBuffer, charset: Charset) = {
+  def decodeHStoreBinary(buf: ByteBuf, charset: Charset) = {
     val count = buf.readInt()
     val pairs = Array.fill(count) {
       val keyLength = buf.readInt()
@@ -53,8 +53,8 @@ object HStores {
     pairs.toMap
   }
 
-  def encodeHStoreBinary(hstore: Map[String, Option[String]], charset: Charset) = {
-    val buf = ChannelBuffers.dynamicBuffer()
+  def encodeHStoreBinary(hstore: Map[String, Option[String]], charset: Charset, allocator: ByteBufAllocator) = {
+    val buf = allocator.buffer()
     buf.writeInt(hstore.size)
     hstore foreach {
       case (key, value) =>

--- a/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.postgres.values
 import java.nio.charset.Charset
 import java.security.MessageDigest
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import scala.annotation.tailrec
 
@@ -16,10 +16,10 @@ object Buffers {
    * Reads a string with C-style '\0' terminator at the end from a buffer.
    */
   @throws(classOf[IndexOutOfBoundsException])
-  def readCString(buffer: ChannelBuffer): String = {
+  def readCString(buffer: ByteBuf): String = {
     @tailrec
-    def countChars(buf: ChannelBuffer, count: Int): Int = {
-      if (!buffer.readable) {
+    def countChars(buf: ByteBuf, count: Int): Int = {
+      if (!buffer.isReadable) {
         throw new IndexOutOfBoundsException("buffer ended, but '\\0' was not found")
       } else if (buffer.readByte() == 0) {
         count
@@ -40,13 +40,13 @@ object Buffers {
     result
   }
 
-  def readBytes(buffer: ChannelBuffer) = {
+  def readBytes(buffer: ByteBuf) = {
     val array = new Array[Byte](buffer.readableBytes())
     buffer.readBytes(array)
     array
   }
 
-  def readString(buffer: ChannelBuffer, charset: Charset) = {
+  def readString(buffer: ByteBuf, charset: Charset) = {
     val array = readBytes(buffer)
     new String(array, charset)
   }

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -7,15 +7,9 @@ import java.time._
 import java.time.temporal.JulianFields
 import java.util.UUID
 
-import org.jboss.netty.buffer.ChannelBuffer
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.{ByteBuf, ByteBufAllocator, Unpooled}
 
 import scala.language.existentials
-
-
-
-
-
 
 /**
   * Typeclass responsible for encoding a parameter of type T for sending to postgres
@@ -23,15 +17,15 @@ import scala.language.existentials
   */
 trait ValueEncoder[T] {
   def encodeText(t: T): Option[String]
-  def encodeBinary(t: T, charset: Charset): Option[ChannelBuffer]
+  def encodeBinary(t: T, charset: Charset, allocator: ByteBufAllocator): Option[ByteBuf]
   def typeName: String
   def elemTypeName: Option[String]
 
   def contraMap[U](fn: U => T, newTypeName: String = this.typeName, newElemTypeName: Option[String] = elemTypeName): ValueEncoder[U] = {
     val prev = this
     new ValueEncoder[U] {
-      def encodeText(u: U) = prev.encodeText(fn(u))
-      def encodeBinary(u: U, charset: Charset) = prev.encodeBinary(fn(u), charset)
+      def encodeText(u: U): Option[String] = prev.encodeText(fn(u))
+      def encodeBinary(u: U, charset: Charset, allocator: ByteBufAllocator): Option[ByteBuf] = prev.encodeBinary(fn(u), charset, allocator)
       val typeName = newTypeName
       val elemTypeName = newElemTypeName
     }
@@ -45,7 +39,7 @@ object ValueEncoder extends LowPriorityEncoder {
   case class Exported[T](encoder: ValueEncoder[T])
 
   private val nullParam = {
-    val buf = ChannelBuffers.buffer(4)
+    val buf = Unpooled.buffer(4)
     buf.writeInt(-1)
     buf
   }
@@ -53,75 +47,69 @@ object ValueEncoder extends LowPriorityEncoder {
   def instance[T](
     instanceTypeName: String,
     text: T => String,
-    binary: (T, Charset) => Option[ChannelBuffer]
+    binary: (T, Charset, ByteBufAllocator) => Option[ByteBuf]
   ): ValueEncoder[T] = new ValueEncoder[T] {
-    def encodeText(t: T) = Option(t).map(text)
-    def encodeBinary(t: T, c: Charset) = binary(t, c)
+    def encodeText(t: T): Option[String] = Option(t).map(text)
+    def encodeBinary(t: T, c: Charset, allocator: ByteBufAllocator): Option[ByteBuf] = binary(t, c, allocator)
     val typeName = instanceTypeName
     val elemTypeName = None
   }
 
-  def encodeText[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8) =
-    Option(t).flatMap(encoder.encodeText) match {
+  def encodeText[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8, allocator: ByteBufAllocator) =
+    Option(t).flatMap((t: T) => encoder.encodeText(t)) match {
       case None => nullParam
       case Some(str) =>
         val bytes = str.getBytes(charset)
-        val buf = ChannelBuffers.buffer(bytes.length + 4)
+        val buf = allocator.buffer(bytes.length + 4)
         buf.writeInt(bytes.length)
         buf.writeBytes(bytes)
         buf
     }
 
-  def encodeBinary[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8) =
-    Option(t).flatMap(encoder.encodeBinary(_, charset)) match {
+  def encodeBinary[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8, allocator: ByteBufAllocator) =
+    Option(t).flatMap((t: T) => encoder.encodeBinary(t, charset, allocator)) match {
       case None => nullParam
       case Some(inBuf) =>
         inBuf.resetReaderIndex()
-        val outBuf = ChannelBuffers.buffer(inBuf.readableBytes() + 4)
+        val outBuf = allocator.buffer(inBuf.readableBytes() + 4)
         outBuf.writeInt(inBuf.readableBytes())
         outBuf.writeBytes(inBuf)
         outBuf
     }
 
-  private def buffer(capacity: Int)(fn: ChannelBuffer => Unit) = {
-    val cb = ChannelBuffers.buffer(capacity)
-    fn(cb)
-    cb
-  }
 
   implicit val string: ValueEncoder[String] = instance(
     "text",
     identity,
-    (s, c) => Option(s).map(s => ChannelBuffers.wrappedBuffer(s.getBytes(c)))
+    (s, c, a) => Option(s).map { s =>
+      val bytes = s.getBytes(c)
+      a.buffer(bytes.length).writeBytes(bytes)
+    }
   )
 
   implicit val boolean: ValueEncoder[Boolean] = instance(
     "bool",
     b => if(b) "t" else "f",
-    (b, c) => Some {
-      val buf = ChannelBuffers.buffer(1)
-      buf.writeByte(if(b) 1.toByte else 0.toByte)
-      buf
-    }
+    (b, c, a) => Some(a.buffer(1).writeByte(if(b) 1.toByte else 0.toByte))
   )
 
   implicit val bytea: ValueEncoder[Array[Byte]] = instance(
     "bytea",
     bytes => "\\x" + bytes.map("%02x".format(_)).mkString,
-    (b, c) => Some(ChannelBuffers.copiedBuffer(b))
+    (b, c, a) => Some(a.buffer(b.length).writeBytes(b))
   )
-  implicit val int2: ValueEncoder[Short] = instance("int2", _.toString, (i, c) => Some(buffer(2)(_.writeShort(i))))
-  implicit val int4: ValueEncoder[Int] = instance("int4", _.toString, (i, c) => Some(buffer(4)(_.writeInt(i))))
-  implicit val int8: ValueEncoder[Long] = instance("int8", _.toString, (i, c) => Some(buffer(8)(_.writeLong(i))))
-  implicit val float4: ValueEncoder[Float] = instance("float4", _.toString, (i, c) => Some(buffer(4)(_.writeFloat(i))))
-  implicit val float8: ValueEncoder[Double] = instance("float8", _.toString, (i, c) => Some(buffer(8)(_.writeDouble(i))))
-  implicit val date: ValueEncoder[LocalDate] = instance("date", _.toString, (i, c) =>
-    Option(i).map(i => buffer(4)(_.writeInt((i.getLong(JulianFields.JULIAN_DAY) - 2451545).toInt)))
+  implicit val int2: ValueEncoder[Short] = instance("int2", _.toString, (i, c, a) => Some(a.buffer(2).writeShort(i)))
+  implicit val int4: ValueEncoder[Int] = instance("int4", _.toString, (i, c, a) => Some(a.buffer(4).writeInt(i)))
+  implicit val int8: ValueEncoder[Long] = instance("int8", _.toString, (i, c, a) => Some(a.buffer(8).writeLong(i)))
+  implicit val float4: ValueEncoder[Float] = instance("float4", _.toString, (i, c, a) => Some(a.buffer(4).writeFloat(i)))
+  implicit val float8: ValueEncoder[Double] = instance("float8", _.toString, (i, c, a) => Some(a.buffer(8).writeDouble(i)))
+  implicit val date: ValueEncoder[LocalDate] = instance("date", _.toString, (i, c, a) =>
+    Option(i).map(i => a.buffer(4).writeInt((i.getLong(JulianFields.JULIAN_DAY) - 2451545).toInt))
   )
   implicit val timestamp: ValueEncoder[LocalDateTime] = instance(
     "timestamp",
     t => java.sql.Timestamp.valueOf(t).toString,
-    (ts, c) => Option(ts).map(ts => DateTimeUtils.writeTimestamp(ts))
+    (ts, c, a) => Option(ts).map(ts => DateTimeUtils.writeTimestamp(ts, a))
   )
   implicit val timestampTz: ValueEncoder[ZonedDateTime] = instance(
     "timestamptz", { t =>
@@ -129,61 +117,59 @@ object ValueEncoder extends LowPriorityEncoder {
       val hours = (offs.getOffset.getTotalSeconds / 3600).formatted("%+03d")
       Timestamp.from(t.toInstant).toString + hours
     },
-    (ts, c) => Option(ts).map(ts => DateTimeUtils.writeTimestampTz(ts))
+    (ts, c, a) => Option(ts).map(ts => DateTimeUtils.writeTimestampTz(ts, a))
   )
   implicit val instant: ValueEncoder[Instant] = instance(
     "timestamptz",
     i => Timestamp.from(i).toString + "+00",
-    (ts, c) => Option(ts).map(ts => DateTimeUtils.writeInstant(ts))
+    (ts, c, a) => Option(ts).map(ts => DateTimeUtils.writeInstant(ts, a))
   )
   implicit val time: ValueEncoder[LocalTime] = instance(
     "time",
     t => t.toString,
-    (t, c) => Option(t).map(t => buffer(8)(_.writeLong(t.toNanoOfDay / 1000)))
+    (t, c, a) => Option(t).map(t => a.buffer(8).writeLong(t.toNanoOfDay / 1000))
   )
   implicit val timeTz: ValueEncoder[OffsetTime] = instance(
     "timetz",
     t => t.toString,
-    (t, c) => Option(t).map(DateTimeUtils.writeTimeTz)
+    (t, c, a) => Option(t).map(DateTimeUtils.writeTimeTz(_, a))
   )
   implicit val interval: ValueEncoder[Interval] = instance(
     "interval",
     i => i.toString,
-    (i, c) => Option(i).map(DateTimeUtils.writeInterval)
+    (i, c, a) => Option(i).map(DateTimeUtils.writeInterval(_, a))
   )
   implicit val numeric: ValueEncoder[BigDecimal] = instance(
     "numeric",
     d => d.bigDecimal.toPlainString,
-    (d, c) => Option(d).map(d => Numerics.writeNumeric(d))
+    (d, c, a) => Option(d).map(d => Numerics.writeNumeric(d, a))
   )
   implicit val numericJava: ValueEncoder[java.math.BigDecimal] = instance(
     "numeric",
     d => d.toPlainString,
-    (d, c) => Option(d).map(d => Numerics.writeNumeric(BigDecimal(d)))
+    (d, c, a) => Option(d).map(d => Numerics.writeNumeric(BigDecimal(d), a))
   )
   implicit val numericBigInt: ValueEncoder[BigInt] = instance(
     "numeric",
     i => i.toString,
-    (i, c) => Option(i).map(i => Numerics.writeNumeric(BigDecimal(i)))
+    (i, c, a) => Option(i).map(i => Numerics.writeNumeric(BigDecimal(i), a))
   )
   implicit val numericJavaBigInt: ValueEncoder[java.math.BigInteger] = instance(
     "numeric",
     i => i.toString,
-    (i, c) => Option(i).map(i => Numerics.writeNumeric(BigDecimal(i)))
+    (i, c, a) => Option(i).map(i => Numerics.writeNumeric(BigDecimal(i), a))
   )
   implicit val uuid: ValueEncoder[UUID] = instance(
     "uuid",
     u => u.toString,
-    (u, c) => Option(u).map(u => buffer(16) {
-      b =>
-        b.writeLong(u.getMostSignificantBits)
-        b.writeLong(u.getLeastSignificantBits)
-    })
+    (u, c, a) => Option(u).map(u => a.buffer(16)
+      .writeLong(u.getMostSignificantBits)
+      .writeLong(u.getLeastSignificantBits))
   )
   implicit val hstore: ValueEncoder[Map[String, Option[String]]] = instance[Map[String, Option[String]]](
     "hstore",
     m => HStores.formatHStoreString(m),
-    (m, c) => Option(m).map(HStores.encodeHStoreBinary(_, c))
+    (m, c, a) => Option(m).map(HStores.encodeHStoreBinary(_, c, a))
   )
   implicit val hstoreNoNulls: ValueEncoder[Map[String, String]] = hstore.contraMap {
     m: Map[String, String] => m.mapValues(Option(_))
@@ -192,8 +178,8 @@ object ValueEncoder extends LowPriorityEncoder {
   implicit val jsonb: ValueEncoder[JSONB] = instance[JSONB](
     "jsonb",
     j => JSONB.stringify(j),
-    (j, c) => {
-      val cb = ChannelBuffers.buffer(1 + j.bytes.length)
+    (j, c, a) => {
+      val cb = a.buffer(1 + j.bytes.length)
       cb.writeByte(1)
       cb.writeBytes(j.bytes)
       Some(cb)
@@ -204,8 +190,8 @@ object ValueEncoder extends LowPriorityEncoder {
     new ValueEncoder[Option[T]] {
       val typeName = encodeT.typeName
       val elemTypeName = encodeT.elemTypeName
-      def encodeText(optT: Option[T]) = optT.flatMap(encodeT.encodeText)
-      def encodeBinary(tOpt: Option[T], c: Charset) = tOpt.flatMap(t => encodeT.encodeBinary(t, c))
+      def encodeText(optT: Option[T]): Option[String] = optT.flatMap((t: T) => encodeT.encodeText(t))
+      def encodeBinary(tOpt: Option[T], c: Charset, allocator: ByteBufAllocator): Option[ByteBuf] = tOpt.flatMap(t => encodeT.encodeBinary(t, c, allocator))
     }
 
   @inline final implicit def some[T](implicit encodeT: ValueEncoder[T]): ValueEncoder[Some[T]] =
@@ -214,8 +200,8 @@ object ValueEncoder extends LowPriorityEncoder {
   implicit object none extends ValueEncoder[None.type] {
     val typeName = "null"
     val elemTypeName = None
-    def encodeText(none: None.type) = None
-    def encodeBinary(none: None.type, c: Charset) = None
+    def encodeText(none: None.type): Option[String] = None
+    def encodeBinary(none: None.type, c: Charset, allocator: ByteBufAllocator): Option[ByteBuf] = None
   }
 }
 

--- a/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionQuerySpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionQuerySpec.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.postgres.connection
 import com.twitter.finagle.postgres.Spec
 import com.twitter.finagle.postgres.messages._
 import com.twitter.finagle.postgres.values.Charsets
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 
 class ConnectionQuerySpec extends Spec {
   "A postgres connection" should {
@@ -74,8 +74,8 @@ class ConnectionQuerySpec extends Spec {
     "handle a select query" in {
       val connection = new Connection(Connected)
 
-      val row1 = DataRow(Array(Some(ChannelBuffers.copiedBuffer("donald@duck.com".getBytes(Charsets.Utf8)))))
-      val row2 = DataRow(Array(Some(ChannelBuffers.copiedBuffer("daisy@duck.com".getBytes(Charsets.Utf8)))))
+      val row1 = DataRow(Array(Some(Unpooled.copiedBuffer("donald@duck.com".getBytes(Charsets.Utf8)))))
+      val row2 = DataRow(Array(Some(Unpooled.copiedBuffer("daisy@duck.com".getBytes(Charsets.Utf8)))))
 
       connection.send(Query("select * from emails"))
       connection.receive(RowDescription(Array(FieldDescription("email",16728,2,1043,-1,-1,0))))

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -7,7 +7,6 @@ import com.twitter.finagle.Postgres
 import com.twitter.finagle.postgres.values.{ValueDecoder, ValueEncoder}
 import com.twitter.finagle.postgres.{Generators, PostgresClient, ResultSet, Spec}
 import com.twitter.util.Await
-import org.jboss.netty.buffer.ChannelBuffers
 import org.scalacheck.Arbitrary
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import Generators._

--- a/src/test/scala/com/twitter/finagle/postgres/messages/PacketSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/messages/PacketSpec.scala
@@ -1,51 +1,53 @@
 package com.twitter.finagle.postgres.messages
 
 import com.twitter.finagle.postgres.Spec
+import io.netty.buffer.UnpooledByteBufAllocator
 
 class PacketSpec extends Spec {
+  val allocator = UnpooledByteBufAllocator.DEFAULT
   "Packet" should {
     "encode an empty packet" in {
-      val pack = PacketBuilder().toPacket.encode
+      val pack = PacketBuilder(allocator).toPacket.encode(allocator)
 
       pack.readInt must equal(4)
     }
 
     "encode a one byte packet" in {
-      val pack = PacketBuilder().writeByte(30).toPacket.encode
+      val pack = PacketBuilder(allocator).writeByte(30).toPacket.encode(allocator)
 
       pack.readInt must equal(5)
       pack.readByte must equal(30)
     }
 
     "encode a one char packet" in {
-      val pack = PacketBuilder().writeChar('c').toPacket.encode
+      val pack = PacketBuilder(allocator).writeChar('c').toPacket.encode(allocator)
 
       pack.readInt must equal(5)
       pack.readByte.asInstanceOf[Char] must equal('c')
     }
 
     "encode a one short packet" in {
-      val pack = PacketBuilder().writeShort(30).toPacket.encode
+      val pack = PacketBuilder(allocator).writeShort(30).toPacket.encode(allocator)
 
       pack.readInt must equal(6)
       pack.readShort must equal(30)
     }
 
     "encode a one int packet" in {
-      val pack = PacketBuilder().writeInt(30).toPacket.encode
+      val pack = PacketBuilder(allocator).writeInt(30).toPacket.encode(allocator)
 
       pack.readInt must equal(8)
       pack.readInt must equal(30)
     }
 
     "encode a one string packet" in {
-      val pack = PacketBuilder().writeCString("two").toPacket.encode
+      val pack = PacketBuilder(allocator).writeCString("two").toPacket.encode(allocator)
 
       pack.readInt must equal(8)
     }
 
     "encode a packet with chars" in {
-      val pack = PacketBuilder('c').writeInt(30).toPacket.encode
+      val pack = PacketBuilder('c', allocator).writeInt(30).toPacket.encode(allocator)
 
       pack.readByte.asInstanceOf[Char] must equal('c')
       pack.readInt must equal(8)

--- a/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
@@ -1,16 +1,16 @@
 package com.twitter.finagle.postgres.values
 
 import com.twitter.finagle.postgres.Spec
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import com.twitter.finagle.postgres.Generators._
+import io.netty.buffer.{ByteBuf, Unpooled, UnpooledByteBufAllocator}
 
 class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
   "Buffers.readCString" should {
-    def newBuffer(): (ChannelBuffer, String, String) = {
+    def newBuffer(): (ByteBuf, String, String) = {
       val str = "Some string"
       val cStr = str + '\u0000'
-      val buffer = ChannelBuffers.copiedBuffer(cStr, Charsets.Utf8)
+      val buffer = Unpooled.copiedBuffer(cStr, Charsets.Utf8)
 
       (buffer, str, cStr)
     }
@@ -40,7 +40,7 @@ class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
     }
 
     "throw an appropriate exception if string passed is not C style" in {
-      val bufferWithWrongString = ChannelBuffers.copiedBuffer("not a C style string", Charsets.Utf8)
+      val bufferWithWrongString = Unpooled.copiedBuffer("not a C style string", Charsets.Utf8)
 
       an[IndexOutOfBoundsException] must be thrownBy {
         Buffers.readCString(bufferWithWrongString)
@@ -101,7 +101,7 @@ class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
   "Numeric utils" should {
     "write a numeric value" in forAll {
       bd: BigDecimal =>
-        val read = Numerics.readNumeric(Numerics.writeNumeric(bd))
+        val read = Numerics.readNumeric(Numerics.writeNumeric(bd, UnpooledByteBufAllocator.DEFAULT))
         read must equal (bd)
     }
   }


### PR DESCRIPTION
This PR upgrades finagle-postgres to use finagle-netty4 (fixes #70). Some notes:

* The strategy for allocation is to explicitly pass around a `ByteBufAllocator` in most cases. ~~Only in two places do we create an allocator (maybe these two could be unified, somehow)~~ (allocator is now taken from Finagle's param stack)
* I didn't handle the deprecation of `Ssl`. It says to use netty4 factories, but I didn't dig into what that entails. I'll open a new issue for that.
* In `PacketDecoder`, where we used to slice a buffer, I changed it to copy instead. I couldn't get reference counting correct for the sliced buffer (if I retained it, I got a "SEVERE LEAK" warning; if I didn't I got `IllegalReferenceCountException` everywhere). I doubt there's a significant performance impact, but maybe we should revisit that (since `PacketDecoder` is fairly central).