### PR TITLE
Closes #75 - Client memoize 

### DIFF
--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -72,7 +72,7 @@ class CustomTypesSpec extends Spec with GeneratorDrivenPropertyChecks {
 
     s"A $mode postgres client with $paramsMode params" should {
       "retrieve the available types from the remote DB" in {
-        val types = Await.result(client.typeMap)
+        val types = Await.result(client.typeMap())
         assert(types.nonEmpty)
         assert(types != PostgresClient.defaultTypes)
       }


### PR DESCRIPTION
This closes #75:
 - The strategy was to find a way to cache only successful evaluations of the `typeMap`. 
 - I chose to use the `Refresh` since it provides memoization for futures and doesn't cache failed ones.
 - `Refresh` provides us with an API to cache values that don't change often so we don't have to call the database every time and we also don't cache failed futures.
 - I also had to make sure that for when using the `prepareAndQuery` and the `prepareAndExecute` that the `typeMap` had been previously evaluated, that's why I added a `flatMap` on those two methods.