### PR TITLE
Don't include password in stack registry

### DIFF
--- a/src/main/scala/com/twitter/finagle/Postgres.scala
+++ b/src/main/scala/com/twitter/finagle/Postgres.scala
@@ -43,7 +43,10 @@ object Postgres {
   object User { implicit object param extends RequiredParam[User]("User") }
 
   case class Password(password: Option[String]) extends AnyVal
-  object Password { implicit val param = Param(Password(None)) }
+  implicit object Password extends Stack.Param[Password] {
+    override def default: Password = Password(None)
+    override def show(p: Password): Seq[(String, () => String)] = Nil
+  }
 
   case class Database(database: String) extends AnyVal
   object Database { implicit object param extends RequiredParam[Database]("Database") }


### PR DESCRIPTION
Closes #77 - change the show method from the Password object to not return the password in plain text.
This will make sure that the password is not available in plain text in the global registry and not
available to be requested.