### PR TITLE
Fix unsafe ChannelBuffer sharing for Nones in ValueEncoder

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -63,7 +63,7 @@ object ValueEncoder extends LowPriorityEncoder {
 
   def encodeText[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8) =
     Option(t).flatMap(encoder.encodeText) match {
-      case None => nullParam
+      case None => nullParam.duplicate()
       case Some(str) =>
         val bytes = str.getBytes(charset)
         val buf = ChannelBuffers.buffer(bytes.length + 4)
@@ -74,7 +74,7 @@ object ValueEncoder extends LowPriorityEncoder {
 
   def encodeBinary[T](t: T, encoder: ValueEncoder[T], charset: Charset = StandardCharsets.UTF_8) =
     Option(t).flatMap(encoder.encodeBinary(_, charset)) match {
-      case None => nullParam
+      case None => nullParam.duplicate()
       case Some(inBuf) =>
         inBuf.resetReaderIndex()
         val outBuf = ChannelBuffers.buffer(inBuf.readableBytes() + 4)


### PR DESCRIPTION
I found that when I ran a bunch of queries in parallel, I got bizarre index-out-of-bounds errors in param encoding (had to add a `Monitor` to my client to find the line numbers) almost every time. I read through the Finagle-Postgres and Netty `ChannelBuffer` code and could not figure out how the errors could possibly happen, and thus theorized that there could be a race condition somewhere. Sure enough, when I shrunk my Netty 3 worker pool to have only one thread, the problem went away. I did some more reading and thinking and eventually realized: Netty `ChannelBuffers` are not thread safe and yet there is a single shared `val` for `nullParam` returned for all cases when an `None` is encoded. This PR updates text and binary encoding to use `duplicate` to provision a duplicated `ChannelBuffer` (shared data, separate reader & writer indices, and thus hopefully safe based on actual usage patterns). This fixed the observed bizarre behavior, even when the worker pool had many threads.