### PR TITLE
Prepend class name to connection / state machine loggers.

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/connection/Connection.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/Connection.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable.ListBuffer
  */
 class Connection(startState: State = AuthenticationRequired) {
   val id = Connection.nextId()
-  private[this] val logger = Logger(s"connection-$id")
+  private[this] val logger = Logger(s"${getClass.getName}.connection-$id")
   private[this] val stateMachine = new ConnectionStateMachine(startState, id)
 
 

--- a/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable.ListBuffer
  * See associated Postgres documentation: http://www.postgresql.org/docs/9.0/static/protocol-flow.html
  */
 class ConnectionStateMachine(state: State = AuthenticationRequired, val id: Int) extends StateMachine[Message, PgResponse, State] {
-  private[this] val logger = Logger(s"psql state machine:$id")
+  private[this] val logger = Logger(s"${getClass.getName}.psql state machine:$id")
 
   startState(state)
 

--- a/src/main/scala/com/twitter/finagle/postgres/connection/StateMachine.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/StateMachine.scala
@@ -20,7 +20,7 @@ trait StateMachine[E, R, S] {
 
   val id: Int
 
-  private[this] val logger = Logger(s"state machine-$id")
+  private[this] val logger = Logger(s"${getClass.getName}.state machine-$id")
   private[this] var transitionFunction: Transition = Undefined
 
   @volatile private[this] var currentState: S = _


### PR DESCRIPTION
This makes it easier to filter out messages in logback etc.