### PR TITLE
Aggregate finagle-postgres with finagle-postgres-shapeless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,10 +72,13 @@ lazy val publishSettings = Seq(
 
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
+lazy val shapelessRef = LocalProject("finagle-postgres-shapeless")
+
 lazy val `finagle-postgres` = project.in(file("."))
   .settings(moduleName := "finagle-postgres")
   .settings(allSettings)
   .configs(IntegrationTest)
+  .aggregate(shapelessRef)
 
 lazy val `finagle-postgres-shapeless` = project
   .settings(moduleName := "finagle-postgres-shapeless")
@@ -112,11 +115,6 @@ lazy val docs = project
 parallelExecution in Test := false
 
 javaOptions in Test += "-Duser.timezone=UTC"
-
-test in Test in `finagle-postgres` := {
-  (test in Test in `finagle-postgres`).value
-  (test in Test in `finagle-postgres-shapeless`).value
-}
 
 scalacOptions ++= Seq(
   "-deprecation"


### PR DESCRIPTION
Problem:
Because the projects were not aggregated we had to have separate release
processes and some logic to run both modules tests.

Solution:
Aggregate both modules.

Result:
Now we have a single process for releasing and testing both modules.