### PR TITLE
Update Finagle to 18.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ lazy val buildSettings = Seq(
 val baseSettings = Seq(
   resolvers += Resolver.bintrayRepo("jeremyrsmith", "maven"),
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-core" % "18.2.0",
-    "com.twitter" %% "finagle-netty3" % "18.2.0",
+    "com.twitter" %% "finagle-core" % "18.12.0",
+    "com.twitter" %% "finagle-netty3" % "18.12.0",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test,it",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test,it",
     "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test,it",


### PR DESCRIPTION
This is based off and replaces #105. Some APIs were removed so I had to change the SSL negotiation logic a bit. We're not failing fast if the remote address not an `InetSocketAddress` (I believe this should never happen in practice).