### PR TITLE
 upgrade netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import ReleaseTransformations._
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.11.12","2.12.4"),
+  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.11.12","2.12.8"),
   fork in Test := true
 )
 
@@ -11,7 +11,7 @@ val baseSettings = Seq(
   resolvers += Resolver.bintrayRepo("jeremyrsmith", "maven"),
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-core" % "19.3.0",
-    "com.twitter" %% "finagle-netty3" % "19.3.0",
+    "com.twitter" %% "finagle-netty4" % "19.3.0",
     "org.scalatest" %% "scalatest" % "3.0.6" % "test,it",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test,it",
     "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test,it",

--- a/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
+++ b/finagle-postgres-shapeless/src/test/scala/com/twitter/finagle/postgres/generic/EnumSpec.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import com.twitter.finagle.postgres.generic.enumeration.InvalidValue
 import com.twitter.finagle.postgres.values.{ValueDecoder, ValueEncoder}
 import com.twitter.util.{Return, Throw}
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 import org.scalatest.{FlatSpec, Matchers}
 
 
@@ -32,19 +32,19 @@ class EnumSpec extends FlatSpec with Matchers {
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseOne", UTF8),
+      Unpooled.copiedBuffer("CaseOne", UTF8),
       UTF8
     ) shouldEqual Return(CaseOne)
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseTwo", UTF8),
+      Unpooled.copiedBuffer("CaseTwo", UTF8),
       UTF8
     ) shouldEqual Return(CaseTwo)
 
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CaseThree", UTF8),
+      Unpooled.copiedBuffer("CaseThree", UTF8),
       UTF8
     ) shouldEqual Return(CaseThree)
 
@@ -56,7 +56,7 @@ class EnumSpec extends FlatSpec with Matchers {
     decoder.decodeText("enum_recv", "CasePurple") shouldEqual Throw(InvalidValue("CasePurple"))
     decoder.decodeBinary(
       "enum_recv",
-      ChannelBuffers.copiedBuffer("CasePurple", UTF8),
+      Unpooled.copiedBuffer("CasePurple", UTF8),
       UTF8
     ) shouldEqual Throw(InvalidValue("CasePurple"))
 

--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.postgres.values._
 import com.twitter.finagle.{Service, ServiceFactory, Status}
 import com.twitter.logging.Logger
 import com.twitter.util._
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import scala.language.{existentials, implicitConversions}
 import scala.util.Random
@@ -234,7 +234,7 @@ class PostgresClientImpl(
       }
     }
 
-    private[this] def bind(params: Seq[ChannelBuffer]): Future[Unit] = {
+    private[this] def bind(params: Seq[ByteBuf]): Future[Unit] = {
       val req =  Bind(
         portal = name,
         name = name,

--- a/src/main/scala/com/twitter/finagle/postgres/Responses.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/Responses.scala
@@ -11,7 +11,7 @@ import com.twitter.util.Try
 import Try._
 import com.twitter.finagle.postgres.PostgresClient.TypeSpecifier
 import com.twitter.finagle.postgres.codec.NullValue
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import scala.language.existentials
 
@@ -42,14 +42,14 @@ trait Row {
 }
 
 object Row {
-  def apply(values: Array[Option[ChannelBuffer]], rowFormat: RowFormat): Row = RowImpl(values, rowFormat)
+  def apply(values: Array[Option[ByteBuf]], rowFormat: RowFormat): Row = RowImpl(values, rowFormat)
 }
 
 /*
  * Convenience wrapper around a set of row values. Supports lookup by name.
  */
 case class RowImpl(
-  values: Array[Option[ChannelBuffer]],
+  values: Array[Option[ByteBuf]],
   rowFormat: RowFormat
 ) extends Row {
 

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.postgres.messages
 import com.twitter.finagle.postgres.values.Buffers
 import com.twitter.logging.Logger
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 /*
  * Class for converting packets into BackendMessages.
@@ -105,8 +105,8 @@ class BackendMessageParser {
   def parseE(packet: Packet): Option[BackendMessage] = {
     val Packet(_, _, content, _) = packet
 
-    def fieldStream(buf: ChannelBuffer):Stream[(Char,String)] =
-      if(buf.readable)
+    def fieldStream(buf: ByteBuf):Stream[(Char,String)] =
+      if(buf.isReadable)
         Buffers.readCString(buf) match {
           case "" => Stream.empty
           case nonempty => (nonempty.splitAt(1) match { case (fieldId, value) => (fieldId.charAt(0), value) }) #:: fieldStream(buf)
@@ -125,7 +125,7 @@ class BackendMessageParser {
       Some(SslNotSupported)
     } else {
       val builder = new StringBuilder()
-      while (content.readable) {
+      while (content.isReadable) {
         builder.append(Buffers.readCString(content))
       }
 
@@ -166,7 +166,7 @@ class BackendMessageParser {
     val Packet(_, _, content, _) = packet
 
     val fieldNumber = content.readShort
-    val fields = new Array[Option[ChannelBuffer]](fieldNumber)
+    val fields = new Array[Option[ByteBuf]](fieldNumber)
 
     for (i <- 0.until(fieldNumber)) {
       val length = content.readInt

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle.postgres.messages
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 /**
  * Responses sent from Postgres back to the client.
@@ -40,7 +40,7 @@ case class FieldDescription(
     dataTypeModifier: Int,
     fieldFormat: Short)
 
-case class DataRow(data: Array[Option[ChannelBuffer]]) extends BackendMessage
+case class DataRow(data: Array[Option[ByteBuf]]) extends BackendMessage
 
 /*
  * Sub-message types used to complete a command.

--- a/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/FrontendMessages.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.postgres.messages
 
 import com.twitter.finagle.postgres.values.{Strings, Convert}
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 /**
  * Messages sent to Postgres from the client.
@@ -58,7 +58,7 @@ case class Parse(
 }
 
 case class Bind(portal: String = Strings.empty, name: String = Strings.empty, formats: Seq[Int] = Seq(),
-                params: Seq[ChannelBuffer] = Seq(), resultFormats: Seq[Int] = Seq()) extends FrontendMessage {
+                params: Seq[ByteBuf] = Seq(), resultFormats: Seq[Int] = Seq()) extends FrontendMessage {
   def asPacket() = {
     val builder = PacketBuilder('B')
       .writeCString(portal)

--- a/src/main/scala/com/twitter/finagle/postgres/messages/Packet.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/Packet.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.postgres.messages
 
 import com.twitter.finagle.postgres.values.Charsets
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import io.netty.buffer.{ByteBuf, Unpooled}
 
 object Packet {
   val INT_SIZE = 4
@@ -13,9 +13,9 @@ object Packet {
  *
  * Converts content into byte format expected by Postgres.
  */
-case class Packet(code: Option[Char], length: Int, content: ChannelBuffer, inSslNegotation: Boolean = false) {
-  def encode(): ChannelBuffer = {
-    val result = ChannelBuffers.dynamicBuffer()
+case class Packet(code: Option[Char], length: Int, content: ByteBuf, inSslNegotation: Boolean = false) {
+  def encode(): ByteBuf = {
+    val result = Unpooled.buffer()
     code.map { c =>
       result.writeByte(c)
     }
@@ -31,7 +31,7 @@ case class Packet(code: Option[Char], length: Int, content: ChannelBuffer, inSsl
  * Helper class for creating packets from scala types.
  */
 class PacketBuilder(val code: Option[Char]) {
-  private val underlying = ChannelBuffers.dynamicBuffer()
+  private val underlying = Unpooled.buffer()
 
   def writeByte(byte: Byte) = {
     underlying.writeByte(byte)
@@ -43,7 +43,7 @@ class PacketBuilder(val code: Option[Char]) {
 	  this
   }
 
-  def writeBuf(bytes: ChannelBuffer) = {
+  def writeBuf(bytes: ByteBuf) = {
 	  underlying.writeBytes(bytes)
 	  this
   }

--- a/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Arrays.scala
@@ -4,7 +4,7 @@ import scala.collection.immutable.Queue
 import scala.util.parsing.combinator.RegexParsers
 
 import com.twitter.util.{Return, Throw, Try}
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 object Arrays {
 
   object ArrayStringParser extends RegexParsers {
@@ -40,7 +40,7 @@ object Arrays {
     }
   }
 
-  def decodeArrayBinary[T](buf: ChannelBuffer, elemDecoder: ValueDecoder[T]) = {
+  def decodeArrayBinary[T](buf: ByteBuf, elemDecoder: ValueDecoder[T]) = {
     val ndims = buf.readInt()
     val flags = buf.readInt()
     val elemOid = buf.readInt()

--- a/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/HStores.scala
@@ -4,7 +4,7 @@ import java.nio.charset.Charset
 
 import scala.util.parsing.combinator.RegexParsers
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import io.netty.buffer.{ByteBuf, Unpooled}
 
 object HStores {
   object HStoreStringParser extends RegexParsers {
@@ -36,7 +36,7 @@ object HStores {
       s"""$key => $value"""
   }.mkString(",")
 
-  def decodeHStoreBinary(buf: ChannelBuffer, charset: Charset) = {
+  def decodeHStoreBinary(buf: ByteBuf, charset: Charset) = {
     val count = buf.readInt()
     val pairs = Array.fill(count) {
       val keyLength = buf.readInt()
@@ -54,7 +54,7 @@ object HStores {
   }
 
   def encodeHStoreBinary(hstore: Map[String, Option[String]], charset: Charset) = {
-    val buf = ChannelBuffers.dynamicBuffer()
+    val buf = Unpooled.buffer()
     buf.writeInt(hstore.size)
     hstore foreach {
       case (key, value) =>

--- a/src/main/scala/com/twitter/finagle/postgres/values/Numerics.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Numerics.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.postgres.values
 
 import java.math.BigInteger
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import io.netty.buffer.{ByteBuf, Unpooled}
 
 private object Numerics {
   private val NUMERIC_POS = 0x0000
@@ -12,13 +12,13 @@ private object Numerics {
   private val NumericDigitBaseExponent = 4
   val biBase = BigInteger.valueOf(10000)
 
-  private def getUnsignedShort(buf: ChannelBuffer) = {
+  private def getUnsignedShort(buf: ByteBuf) = {
     val high = buf.readByte().toInt
     val low = buf.readByte()
     (high << 8) | low
   }
 
-  def readNumeric(buf: ChannelBuffer) = {
+  def readNumeric(buf: ByteBuf) = {
     val len = getUnsignedShort(buf)
     val weight = buf.readShort()
     val sign = getUnsignedShort(buf)
@@ -91,7 +91,7 @@ private object Numerics {
       2 + //scale
       digits.length * 2 //a short for each digit
 
-    val buf = ChannelBuffers.wrappedBuffer(new Array[Byte](bufSize))
+    val buf = Unpooled.wrappedBuffer(new Array[Byte](bufSize))
 
     buf.resetWriterIndex()
     buf.writeShort(digits.length)

--- a/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/Utils.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.postgres.values
 import java.nio.charset.Charset
 import java.security.MessageDigest
 
-import org.jboss.netty.buffer.ChannelBuffer
+import io.netty.buffer.ByteBuf
 
 import scala.annotation.tailrec
 
@@ -16,10 +16,10 @@ object Buffers {
    * Reads a string with C-style '\0' terminator at the end from a buffer.
    */
   @throws(classOf[IndexOutOfBoundsException])
-  def readCString(buffer: ChannelBuffer): String = {
+  def readCString(buffer: ByteBuf): String = {
     @tailrec
-    def countChars(buf: ChannelBuffer, count: Int): Int = {
-      if (!buffer.readable) {
+    def countChars(buf: ByteBuf, count: Int): Int = {
+      if (!buffer.isReadable) {
         throw new IndexOutOfBoundsException("buffer ended, but '\\0' was not found")
       } else if (buffer.readByte() == 0) {
         count
@@ -40,13 +40,13 @@ object Buffers {
     result
   }
 
-  def readBytes(buffer: ChannelBuffer) = {
+  def readBytes(buffer: ByteBuf) = {
     val array = new Array[Byte](buffer.readableBytes())
     buffer.readBytes(array)
     array
   }
 
-  def readString(buffer: ChannelBuffer, charset: Charset) = {
+  def readString(buffer: ByteBuf, charset: Charset) = {
     val array = readBytes(buffer)
     new String(array, charset)
   }

--- a/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionQuerySpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/connection/ConnectionQuerySpec.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.postgres.connection
 import com.twitter.finagle.postgres.Spec
 import com.twitter.finagle.postgres.messages._
 import com.twitter.finagle.postgres.values.Charsets
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 
 class ConnectionQuerySpec extends Spec {
   "A postgres connection" should {
@@ -74,8 +74,8 @@ class ConnectionQuerySpec extends Spec {
     "handle a select query" in {
       val connection = new Connection(Connected)
 
-      val row1 = DataRow(Array(Some(ChannelBuffers.copiedBuffer("donald@duck.com".getBytes(Charsets.Utf8)))))
-      val row2 = DataRow(Array(Some(ChannelBuffers.copiedBuffer("daisy@duck.com".getBytes(Charsets.Utf8)))))
+      val row1 = DataRow(Array(Some(Unpooled.copiedBuffer("donald@duck.com".getBytes(Charsets.Utf8)))))
+      val row2 = DataRow(Array(Some(Unpooled.copiedBuffer("daisy@duck.com".getBytes(Charsets.Utf8)))))
 
       connection.send(Query("select * from emails"))
       connection.receive(RowDescription(Array(FieldDescription("email",16728,2,1043,-1,-1,0))))

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.Postgres
 import com.twitter.finagle.postgres.values.{ValueDecoder, ValueEncoder}
 import com.twitter.finagle.postgres.{Generators, PostgresClient, ResultSet, Spec}
 import com.twitter.util.Await
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 import org.scalacheck.Arbitrary
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import Generators._

--- a/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/UtilsSpec.scala
@@ -1,16 +1,16 @@
 package com.twitter.finagle.postgres.values
 
 import com.twitter.finagle.postgres.Spec
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
+import io.netty.buffer.{ByteBuf, Unpooled}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import com.twitter.finagle.postgres.Generators._
 
 class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
   "Buffers.readCString" should {
-    def newBuffer(): (ChannelBuffer, String, String) = {
+    def newBuffer(): (ByteBuf, String, String) = {
       val str = "Some string"
       val cStr = str + '\u0000'
-      val buffer = ChannelBuffers.copiedBuffer(cStr, Charsets.Utf8)
+      val buffer = Unpooled.copiedBuffer(cStr, Charsets.Utf8)
 
       (buffer, str, cStr)
     }
@@ -40,7 +40,7 @@ class UtilsSpec extends Spec with GeneratorDrivenPropertyChecks {
     }
 
     "throw an appropriate exception if string passed is not C style" in {
-      val bufferWithWrongString = ChannelBuffers.copiedBuffer("not a C style string", Charsets.Utf8)
+      val bufferWithWrongString = Unpooled.copiedBuffer("not a C style string", Charsets.Utf8)
 
       an[IndexOutOfBoundsException] must be thrownBy {
         Buffers.readCString(bufferWithWrongString)

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -14,7 +14,7 @@ import com.twitter.finagle.postgres.Spec
 import com.twitter.finagle.postgres.messages.DataRow
 import com.twitter.finagle.postgres.messages.Field
 import com.twitter.util.Await
-import org.jboss.netty.buffer.ChannelBuffers
+import io.netty.buffer.Unpooled
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -42,7 +42,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
         val ResultSet(List(textRow)) = Await.result(client.query(s"SELECT CAST('$escaped'::$typ AS text) AS out"))
         val bytes = binaryRow.get[Array[Byte]]("out")
         val textString = textRow.get[String]("out")
-        val binaryOut = decoder.decodeBinary(recv, ChannelBuffers.wrappedBuffer(bytes), client.charset).get
+        val binaryOut = decoder.decodeBinary(recv, Unpooled.wrappedBuffer(bytes), client.charset).get
         val textOut = decoder.decodeText(recv, textString).get
 
         if(!tester(t, binaryOut))
@@ -81,7 +81,7 @@ class ValuesSpec extends Spec with GeneratorDrivenPropertyChecks {
 
           val List(rowText) = ResultSet(
             Array(Field("column", 0, 0)), StandardCharsets.UTF_8,
-            List(DataRow(Array(Some(ChannelBuffers.copiedBuffer(encodedText, StandardCharsets.UTF_8))))),
+            List(DataRow(Array(Some(Unpooled.copiedBuffer(encodedText, StandardCharsets.UTF_8))))),
             Map(0 -> TypeSpecifier(recv, typ, 0)), ValueDecoder.decoders
           ).rows
 


### PR DESCRIPTION
Upgrade to `finagle-netty4`,
But there are buf leaks. Because `RowImpl`  holds buffers for future value decoding.
So UnpooledByteBufAllocator is enabled by default currently.