### PR TITLE
Fix prepared statements for parallel queries

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/PostgresClientImpl.scala
@@ -158,7 +158,7 @@ class PostgresClientImpl(
       typeMap().flatMap { _ =>
         for {
           service   <- factory()
-          statement = new PreparedStatementImpl("", sql, service)
+          statement = new PreparedStatementImpl(sql, service)
           result    <- statement.selectToStream(params: _*)(f)
         } yield result
       }
@@ -171,7 +171,7 @@ class PostgresClientImpl(
     typeMap().flatMap { _ =>
       for {
         service   <- factory()
-        statement = new PreparedStatementImpl("", sql, service)
+        statement = new PreparedStatementImpl(sql, service)
         OK(count) <- statement.exec(params: _*)
       } yield count
     }
@@ -215,10 +215,11 @@ class PostgresClientImpl(
 
 
   private[this] class PreparedStatementImpl(
-    name: String,
     sql: String,
     service: Service[PgRequest, PgResponse]
   ) extends PreparedStatement {
+
+    private[this] val name = s"fin-pg-$id-" + counter.incrementAndGet
 
     def closeService = service.close()
 
@@ -306,8 +307,6 @@ class PostgresClientImpl(
       }.ensure(service.close())
     }
   }
-
-  private[this] def genName() = s"fin-pg-$id-" + counter.incrementAndGet
 }
 
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.0-SNAPSHOT"
+version in ThisBuild := "0.13.1-SNAPSHOT"


### PR DESCRIPTION
Hello!

We were running into a problem where many prepared queries happening in parallel were getting the wrong set of parameters assigned to them.

The unproven theory is that the prepared query `name` and `portal` values are currently set to `""` potentially causing collisions. I changed all those hardcoded `""` to a generated value called `genName` which contains an  `AtomicInt.incrementAndGet`  -- that seems to fix the bug in our set up: `finagle-postgres 0.11` via `quill-finagle-postgres 3.1.0`

However, I wasn't able to replicate the bug in the specs. Perhaps the problem is that the queries that I am performing are fast enough to not cause a race condition? or maybe the test queries are somehow running in a serialized fashion anyways? not sure :( - I'd gladly re-write the test to verify this behavior successfully, and would love if someone is able to guide me in the right direction.

---

I'd like to add that we are getting several symptoms that all seem to be related with this issue:

1) Sometimes we get `ERROR: portal "" cannot be run` when those parallel queries are getting executed
2) Some of these parallel queries are left idle for a long time, causing us to have to use `pg_terminate_backend` regularly in order to cancel them
3) In one of our setups we had two sets of queries, each with 10 and 12 different parameters, all running simultaneously. In some cases the query expecting 12 parameters was being sent 10, causing the following error:

`bind message supplies 10 parameters, but prepared statement “...” requires 12`

