### PR TITLE
FIX: avoid java.sql.Timestamp since it depends on system timezone

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,8 +128,6 @@ lazy val docs = project
 
 parallelExecution in Test := false
 
-javaOptions in Test += "-Duser.timezone=UTC"
-
 scalacOptions ++= Seq(
   "-deprecation"
 )

--- a/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/values/ValueEncoder.scala
@@ -2,7 +2,6 @@ package com.twitter.finagle.postgres.values
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import java.sql.Timestamp
 import java.time._
 import java.time.temporal.JulianFields
 import java.util.UUID
@@ -120,20 +119,17 @@ object ValueEncoder extends LowPriorityEncoder {
   )
   implicit val timestamp: ValueEncoder[LocalDateTime] = instance(
     "timestamp",
-    t => java.sql.Timestamp.valueOf(t).toString,
+    t => DateTimeUtils.format(t),
     (ts, c) => Option(ts).map(ts => DateTimeUtils.writeTimestamp(ts))
   )
   implicit val timestampTz: ValueEncoder[ZonedDateTime] = instance(
-    "timestamptz", { t =>
-      val offs = t.toOffsetDateTime
-      val hours = (offs.getOffset.getTotalSeconds / 3600).formatted("%+03d")
-      Timestamp.from(t.toInstant).toString + hours
-    },
+    "timestamptz",
+    t => DateTimeUtils.format(t),
     (ts, c) => Option(ts).map(ts => DateTimeUtils.writeTimestampTz(ts))
   )
   implicit val instant: ValueEncoder[Instant] = instance(
     "timestamptz",
-    i => Timestamp.from(i).toString + "+00",
+    i => DateTimeUtils.format(i),
     (ts, c) => Option(ts).map(ts => DateTimeUtils.writeInstant(ts))
   )
   implicit val time: ValueEncoder[LocalTime] = instance(

--- a/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/CustomTypesSpec.scala
@@ -95,7 +95,12 @@ class CustomTypesSpec extends Spec with ScalaCheckDrivenPropertyChecks {
       )
       "parse timestamps with time zone" in test(ValueDecoder.zonedDateTime)(
         "timestamptz",
-        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+        (a, b) =>
+          // when reading the value, the timezone may have changed:
+          //   the binary protocol does not include timezone information (everything is in UTC)
+          //   the text protocol returns in the server's timezone which may be different than the supplied tz.
+          // so we convert the input value to the read value's timezone and then compare them
+          a.withZoneSameInstant(b.getOffset) == b
       )
       "parse times" in test(ValueDecoder.localTime)("time")
       "parse times with timezone" in test(ValueDecoder.offsetTime)("timetz")

--- a/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/values/ValuesSpec.scala
@@ -4,6 +4,7 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.time._
 import java.time.temporal.ChronoField
+import java.util.TimeZone
 
 import com.twitter.finagle.Postgres
 import com.twitter.finagle.postgres.Generators._
@@ -23,88 +24,6 @@ import io.circe.testing.instances.arbitraryJson
 
 class ValuesSpec extends Spec with ScalaCheckDrivenPropertyChecks {
 
-  def test[T : Arbitrary](
-    decoder: ValueDecoder[T],
-    encoder: ValueEncoder[T])(
-    send: String,
-    typ: String,
-    toStr: T => String = (t: T) => t.toString,
-    tester: (T, T) => Boolean = (a: T, b: T) => a == b,
-    nonDefault: Boolean = false)(
-    implicit client: PostgresClient
-  ) = {
-    val recv = send.replace("send", "recv")
-    implicit val dec = decoder
-    forAll {
-      (t: T) =>
-        //TODO: change this once prepared statements are available
-        val escaped = toStr(t).replaceAllLiterally("'", "\\'")
-        val ResultSet(binaryRows) = Await.result(client.query(s"SELECT $send('$escaped'::$typ) AS out"))
-        val binaryRow = Await.result(binaryRows.toSeq).head
-        val ResultSet(textRows) = Await.result(client.query(s"SELECT CAST('$escaped'::$typ AS text) AS out"))
-        val textRow = Await.result(textRows.toSeq).head
-        val bytes = binaryRow.get[Array[Byte]]("out")
-        val textString = textRow.get[String]("out")
-        val binaryOut = decoder.decodeBinary(recv, Unpooled.wrappedBuffer(bytes), client.charset).get
-        val textOut = decoder.decodeText(recv, textString).get
-
-        if(!tester(t, binaryOut))
-          fail(s"binary: $t does not match $binaryOut")
-
-        if(!tester(t, textOut))
-          fail(s"text: $t does not match $textOut")
-
-        val encodedBinary = encoder.encodeBinary(t, client.charset).getOrElse(fail("Binary encoding produced null"))
-        val encodedText = encoder.encodeText(t).getOrElse(fail("Text encoding produced null"))
-
-        val binaryInOut = decoder.decodeBinary(recv, encodedBinary.duplicate(), client.charset).get
-        val textInOut = decoder.decodeText(recv, encodedText).get
-
-        if(!tester(t, binaryInOut))
-          fail(s"binary: $t was encoded/decoded to $binaryInOut")
-
-        if(!tester(t, textInOut))
-          fail(s"text: $t was encoded/decoded to $textInOut")
-
-        if(!nonDefault) {
-          val List(rowBinary) = Await.result(
-            ResultSet(
-              Array(Field("column", 1, 0)), StandardCharsets.UTF_8,
-              AsyncStream.fromSeq(List(DataRow(Array(Some(encodedBinary))))),
-              Map(0 -> TypeSpecifier(recv, typ, 0)), ValueDecoder.decoders
-            ).rows.toSeq.map(_.toList)
-          )
-
-          assert(tester(rowBinary.getAnyOption("column").get.asInstanceOf[T], t))
-          assert(tester(rowBinary.getAnyOption(0).get.asInstanceOf[T], t))
-          assert(tester(rowBinary.getOption[T]("column").get, t))
-          assert(tester(rowBinary.getOption[T](0).get, t))
-          assert(tester(rowBinary.get[T]("column"), t))
-          assert(tester(rowBinary.get[T](0), t))
-          assert(tester(rowBinary.getTry[T]("column").get, t))
-          assert(tester(rowBinary.getTry[T](0).get, t))
-
-          val List(rowText) = Await.result(
-            ResultSet(
-              Array(Field("column", 0, 0)), StandardCharsets.UTF_8,
-              AsyncStream.fromSeq(List(DataRow(Array(Some(Unpooled.copiedBuffer(encodedText, StandardCharsets.UTF_8)))))),
-              Map(0 -> TypeSpecifier(recv, typ, 0)), ValueDecoder.decoders
-            ).rows.toSeq.map(_.toList)
-          )
-
-          assert(tester(rowText.getAnyOption("column").get.asInstanceOf[T], t))
-          assert(tester(rowText.getAnyOption(0).get.asInstanceOf[T], t))
-          assert(tester(rowText.getOption[T]("column").get, t))
-          assert(tester(rowText.getOption[T](0).get, t))
-          assert(tester(rowText.get[T]("column"), t))
-          assert(tester(rowText.get[T](0), t))
-          assert(tester(rowText.getTry[T]("column").get, t))
-          assert(tester(rowText.getTry[T](0).get, t))
-        }
-    }
-  }
-
-
   for {
     hostPort <- sys.env.get("PG_HOST_PORT")
     user <- sys.env.get("PG_USER")
@@ -112,12 +31,105 @@ class ValuesSpec extends Spec with ScalaCheckDrivenPropertyChecks {
     dbname <- sys.env.get("PG_DBNAME")
     useSsl = sys.env.getOrElse("USE_PG_SSL", "0") == "1"
   } yield {
-    implicit val client = Postgres.Client()
+    val client = Postgres.Client()
       .database(dbname)
       .withCredentials(user, password)
       .conditionally(useSsl, _.withTransport.tlsWithoutValidation)
       .withSessionPool.maxSize(1)
       .newRichClient(hostPort)
+
+    def tzSensitive(tst: TimeZone => Unit) = {
+      tst(TimeZone.getTimeZone("UTC"))
+      tst(TimeZone.getTimeZone("America/Montreal"))
+    }
+
+    def test[T: Arbitrary](
+      decoder: ValueDecoder[T],
+      encoder: ValueEncoder[T])(
+      send: String,
+      typ: String,
+      toStr: T => String = (t: T) => t.toString,
+      tester: (T, T) => Boolean = (a: T, b: T) => a == b,
+      nonDefault: Boolean = false,
+      localTz: TimeZone = TimeZone.getDefault
+    ) = {
+      val recv = send.replace("send", "recv")
+      implicit val dec = decoder
+      val oldDefault = TimeZone.getDefault
+      TimeZone.setDefault(localTz)
+      try {
+        forAll {
+          (t: T) =>
+            //TODO: change this once prepared statements are available
+            val escaped = toStr(t).replaceAllLiterally("'", "\\'")
+            val ResultSet(binaryRows) = Await.result(client.query(s"SELECT $send('$escaped'::$typ) AS out"))
+            val binaryRow = Await.result(binaryRows.toSeq).head
+            val ResultSet(textRows) = Await.result(client.query(s"SELECT CAST('$escaped'::$typ AS text) AS out"))
+            val textRow = Await.result(textRows.toSeq).head
+            val bytes = binaryRow.get[Array[Byte]]("out")
+            val textString = textRow.get[String]("out")
+            val binaryOut = decoder.decodeBinary(recv, Unpooled.wrappedBuffer(bytes), client.charset).get
+            val textOut = decoder.decodeText(recv, textString).get
+
+            if (!tester(t, binaryOut))
+              fail(s"binary: $t does not match $binaryOut")
+
+            if (!tester(t, textOut))
+              fail(s"text: $t does not match $textOut")
+
+            val encodedBinary = encoder.encodeBinary(t, client.charset).getOrElse(fail("Binary encoding produced null"))
+            val encodedText = encoder.encodeText(t).getOrElse(fail("Text encoding produced null"))
+
+            val binaryInOut = decoder.decodeBinary(recv, encodedBinary.duplicate(), client.charset).get
+            val textInOut = decoder.decodeText(recv, encodedText).get
+
+            if (!tester(t, binaryInOut))
+              fail(s"binary: $t was encoded/decoded to $binaryInOut")
+
+            if (!tester(t, textInOut))
+              fail(s"text: $t was encoded/decoded to $textInOut")
+
+            if (!nonDefault) {
+              val List(rowBinary) = Await.result(
+                ResultSet(
+                  Array(Field("column", 1, 0)), StandardCharsets.UTF_8,
+                  AsyncStream.fromSeq(List(DataRow(Array(Some(encodedBinary))))),
+                  Map(0 -> TypeSpecifier(recv, typ, 0)), ValueDecoder.decoders
+                ).rows.toSeq.map(_.toList)
+              )
+
+              assert(tester(rowBinary.getAnyOption("column").get.asInstanceOf[T], t))
+              assert(tester(rowBinary.getAnyOption(0).get.asInstanceOf[T], t))
+              assert(tester(rowBinary.getOption[T]("column").get, t))
+              assert(tester(rowBinary.getOption[T](0).get, t))
+              assert(tester(rowBinary.get[T]("column"), t))
+              assert(tester(rowBinary.get[T](0), t))
+              assert(tester(rowBinary.getTry[T]("column").get, t))
+              assert(tester(rowBinary.getTry[T](0).get, t))
+
+              val List(rowText) = Await.result(
+                ResultSet(
+                  Array(Field("column", 0, 0)), StandardCharsets.UTF_8,
+                  AsyncStream.fromSeq(List(DataRow(Array(Some(Unpooled.copiedBuffer(encodedText, StandardCharsets.UTF_8)))))),
+                  Map(0 -> TypeSpecifier(recv, typ, 0)), ValueDecoder.decoders
+                ).rows.toSeq.map(_.toList)
+              )
+
+              assert(tester(rowText.getAnyOption("column").get.asInstanceOf[T], t))
+              assert(tester(rowText.getAnyOption(0).get.asInstanceOf[T], t))
+              assert(tester(rowText.getOption[T]("column").get, t))
+              assert(tester(rowText.getOption[T](0).get, t))
+              assert(tester(rowText.get[T]("column"), t))
+              assert(tester(rowText.get[T](0), t))
+              assert(tester(rowText.getTry[T]("column").get, t))
+              assert(tester(rowText.getTry[T](0).get, t))
+            }
+        }
+      } finally {
+        TimeZone.setDefault(oldDefault)
+      }
+
+    }
 
     "ValueDecoders" should {
       "parse varchars" in test(ValueDecoder.string, ValueEncoder.string)("varcharsend", "varchar")
@@ -130,24 +142,32 @@ class ValuesSpec extends Spec with ScalaCheckDrivenPropertyChecks {
       "parse floats" in test(ValueDecoder.float4, ValueEncoder.float4)("float4send", "numeric")
       "parse doubles" in test(ValueDecoder.float8, ValueEncoder.float8)("float8send", "numeric")
       "parse numerics" in test(ValueDecoder.bigDecimal, ValueEncoder.numeric)("numeric_send", "numeric")
-      "parse timestamps" in test(ValueDecoder.localDateTime, ValueEncoder.timestamp)(
-        "timestamp_send",
-        "timestamp",
-        ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
-        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
-      )
-      "parse timestamps with time zone" in test(ValueDecoder.zonedDateTime, ValueEncoder.timestampTz)(
-        "timestamptz_send",
-        "timestamptz",
-        ts => ts.toOffsetDateTime.toString,
-        (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY),
-        nonDefault = true
-      )
-      "parse timestamps as instants" in test(ValueDecoder.instant, ValueEncoder.instant)(
-        "timestamptz_send",
-        "timestamptz",
-        ts => ts.toString
-      )
+
+      tzSensitive { tz =>
+        s"parse timestamps when local timezone is ${tz.getID}" in test(ValueDecoder.localDateTime, ValueEncoder.timestamp)(
+          "timestamp_send",
+          "timestamp",
+          ts => java.sql.Timestamp.from(ts.atZone(ZoneId.systemDefault()).toInstant).toString,
+          (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY)
+        )
+
+        s"parse timestamps with time zone when local timezone is ${tz.getID}" in
+          test(ValueDecoder.zonedDateTime, ValueEncoder.timestampTz)(
+            "timestamptz_send",
+            "timestamptz",
+            ts => ts.toOffsetDateTime.toString,
+            (a, b) => a.getLong(ChronoField.MICRO_OF_DAY) == b.getLong(ChronoField.MICRO_OF_DAY),
+            nonDefault = true,
+            localTz = tz
+          )
+
+        s"parse timestamps as instants when local timezone is ${tz.getID}" in test(ValueDecoder.instant, ValueEncoder.instant)(
+          "timestamptz_send",
+          "timestamptz",
+          ts => ts.toString,
+          localTz = tz
+        )
+      }
       "parse uuids" in test(ValueDecoder.uuid, ValueEncoder.uuid)("uuid_send", "uuid")
       "parse dates" in test(ValueDecoder.localDate, ValueEncoder.date)("date_send", "date")
 
@@ -173,8 +193,7 @@ class ValuesSpec extends Spec with ScalaCheckDrivenPropertyChecks {
             arbitraryJson.arbitrary.map(_.spaces4),
             arbitraryJson.arbitrary.map(_.spaces2)
           ).map(_.replace("\u0000", "\\u0000"))
-        ),
-        client
+        )
       )
     }
   }


### PR DESCRIPTION
Commit https://github.com/finagle/finagle-postgres/commit/cb0d7f4804ae905427026c29c3e3cd64f9b1ebb9 demonstrates the problem.

When parsing a SQL timestamp using `java.sql.Timestamp.valueOf`, the resulting instant uses the system timezone.

For example:

```
scala> java.time.ZoneId.systemDefault
res0: java.time.ZoneId = America/Montreal

scala> java.sql.Timestamp.valueOf("2020-01-01 00:00:00.0").toInstant
res1: java.time.Instant = 2020-01-01T05:00:00Z
```

This change replaces all the places where manual timezone parsing / formatting was happening with the use of a `DateTimeFormatter` that is compatible with PostgreSQL.

NOTE: this also introduces a functional change where the `ZonedDateTime` type will represent the timezone of the PostgreSQL text output.
Previously, it would clobber this value with the system timezone.
The default decoder for `timestamptz` should probably be chnaged to this one instead of `instant` because of this.