### PR TITLE
Add useful default custom receive functions

### DIFF
--- a/src/main/scala/com/twitter/finagle/Postgres.scala
+++ b/src/main/scala/com/twitter/finagle/Postgres.scala
@@ -73,7 +73,8 @@ object Postgres {
     param.ResponseClassifier(defaultResponseClassifier) +
     Retries.Policy(defaultRetryPolicy) +
     Monitor(PostgresDefaultMonitor) +
-    Allocator(UnpooledByteBufAllocator.DEFAULT)
+    Allocator(UnpooledByteBufAllocator.DEFAULT) +
+    CustomReceiveFunctions(ValueDecoder.decoders orElse { case "noop" => ValueDecoder.unknown })
 
   private def defaultStack = StackClient.newStack[PgRequest, PgResponse]
     .replace(StackClient.Role.prepConn, PrepConnection)


### PR DESCRIPTION
Instead of defining the default CustomReceiveFunctions as an empty partial function, this uses the existing partial function defined in `ValueDecoder` as a default.

The issue is demonstrated by the following code:

```scala
val client =
  Postgres.Client()
    .withCredentials("postgres", None)
    .database("postgres")
    .newRichClient(s"localhost:5432")

Await.result(client.execute("CREATE TABLE person (name VARCHAR(255), age Int)"))
Await.result(client.execute("INSERT INTO person (name, age) VALUES ("Bob", 45), ("Alice", 25)"))

println(Await.result(client.select("SELECT name, age FROM person") { row =>
  val name = row.getAnyOption("name") match {
    case Some(n: String) => n
    case _ => sys.error("failed to read name")
  }
  val age = row.getAnyOption("age") match {
    case Some(a: Int) => a
    case _ => sys.error("failed to read age")
  }
  (name, age)
}))

// expected behavior: Vector(("Bob", 45), ("Alice", 25))
// current behavior: java.lang.RuntimeException: failed to read name
```

Obviously, to avoid this I could just use `row.get` which uses the existing `ValueDecoder`s for `Int` and `String` but when trying to define more complex behavior for decoding like the library [`quill` tries to generalize here with partial functions](https://github.com/getquill/quill/blob/master/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala#L24-L31) it's pretty easy to run into this issue and it's pretty difficult to debug without knowledge of how decoding works in both libraries.