### PR TITLE
Support sending SET commands.

### DIFF
--- a/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/connection/ConnectionStateMachine.scala
@@ -99,6 +99,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired, val id: Int)
     case (CommandComplete(DiscardAll), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
     case (CommandComplete(Begin | Savepoint | Release | RollBack | Commit), SimpleQuery) =>
       (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
+    case (CommandComplete(Set), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
     case (CommandComplete(Do), SimpleQuery) => (None, EmitOnReadyForQuery(CommandCompleteResponse(1)))
 
     case (RowDescription(fields), SimpleQuery) =>
@@ -123,6 +124,7 @@ class ConnectionStateMachine(state: State = AuthenticationRequired, val id: Int)
     case (CommandComplete(Update(count)), ExecutePreparedStatement) => (Some(CommandCompleteResponse(count)), Connected)
     case (CommandComplete(Delete(count)), ExecutePreparedStatement) => (Some(CommandCompleteResponse(count)), Connected)
     case (CommandComplete(Begin), ExecutePreparedStatement) => (Some(CommandCompleteResponse(1)), Connected)
+    case (CommandComplete(Set), ExecutePreparedStatement) => (Some(CommandCompleteResponse(1)), Connected)
     case (CommandComplete(Savepoint), ExecutePreparedStatement) => (Some(CommandCompleteResponse(1)), Connected)
     case (CommandComplete(RollBack), ExecutePreparedStatement) => (Some(CommandCompleteResponse(1)), Connected)
     case (CommandComplete(Commit), ExecutePreparedStatement) => (Some(CommandCompleteResponse(1)), Connected)

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessageParser.scala
@@ -238,6 +238,7 @@ class BackendMessageParser {
           case "DELETE" => Delete(parts(1).toInt)
           case "UPDATE" => Update(parts(1).toInt)
           case "BEGIN"  => Begin
+          case "SET"    => Set
           case "SAVEPOINT" => Savepoint
           case "RELEASE" => Release
           case "ROLLBACK"  => RollBack

--- a/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
+++ b/src/main/scala/com/twitter/finagle/postgres/messages/BackendMessages.scala
@@ -75,6 +75,8 @@ case class Select(count: Int) extends CommandCompleteStatus
 
 case object Begin extends CommandCompleteStatus
 
+case object Set extends CommandCompleteStatus
+
 case object Savepoint extends CommandCompleteStatus
 
 case object Release extends CommandCompleteStatus

--- a/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
+++ b/src/test/scala/com/twitter/finagle/postgres/integration/IntegrationSpec.scala
@@ -380,6 +380,11 @@ class IntegrationSpec extends Spec {
         Await.result(result)
       }
 
+      "support sending SET commands" in {
+        val client = getClient
+        val result = client.query("SET TIME ZONE DEFAULT;")
+        Await.result(result)
+      }
 
       "throw a ServerError" when {
         "query has error" in {


### PR DESCRIPTION
Previous to this change, if you tried to issue a `SET` command,
finagle-postgres would raise an exception telling no completion command
is known for tag `SET`. This patch implements such a response from
server.

`SET` commands are needed for sending runtime settings to postgres
or when trying to set the current transaction isolation level.

See:

https://github.com/getquill/quill/issues/29#issuecomment-560162692